### PR TITLE
feat: enhance api command with info, examples, openapi subcommands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/qa-use",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "packageManager": "bun@^1.3.4",
   "description": "QA automation tool for browser testing with MCP server support",
   "type": "module",

--- a/plugins/qa-use/.claude-plugin/plugin.json
+++ b/plugins/qa-use/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa-use",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Simplified CLI-integrated plugin for E2E testing with essential slash commands plus dynamic API CLI workflows (`qa-use api`). Provides AI-first feature verification, browser automation, and test management. All CLI operations documented in SKILL.md and accessible via `qa-use docs` for harness compatibility.",
   "author": {
     "name": "desplega.ai",

--- a/plugins/qa-use/skills/qa-use/SKILL.md
+++ b/plugins/qa-use/skills/qa-use/SKILL.md
@@ -288,9 +288,16 @@ Use diff output to interact with newly appeared elements directly, without runni
 
 | Command | Description |
 |---------|-------------|
+| `qa-use api` | Show help and available subcommands |
 | `qa-use api ls` | List available `/api/v1/*` routes from OpenAPI |
 | `qa-use api ls --refresh` | Force refresh OpenAPI cache |
 | `qa-use api ls --offline` | Use cached OpenAPI metadata only |
+| `qa-use api info /api/v1/<route>` | Show route details: parameters, request body, responses |
+| `qa-use api info /api/v1/<route> -X POST` | Show info for specific HTTP method |
+| `qa-use api info /api/v1/<route> --json` | Route info as JSON |
+| `qa-use api examples` | Show usage examples |
+| `qa-use api openapi` | Print OpenAPI spec URL |
+| `qa-use api openapi --raw` | Dump full OpenAPI spec as JSON |
 | `qa-use api /api/v1/tests` | Call endpoint (method inferred when possible) |
 | `qa-use api -X GET /api/v1/test-runs -f limit=5` | GET with query fields |
 | `qa-use api -X POST /api/v1/tests-actions/run --input body.json` | POST with JSON body file |

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -222,6 +222,45 @@ await section('Section 3: Test Runner', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Section 4: API Subcommands
+// ---------------------------------------------------------------------------
+
+await section('Section 4: API Subcommands', () => {
+	// 1. Bare `api` shows help (exit 0)
+	const helpOut = runOrThrow(['api']);
+	assert(helpOut.includes('Call desplega.ai API endpoints'), 'Bare api shows help text');
+
+	// 2. `api ls` lists endpoints
+	const lsOut = runOrThrow(['api', 'ls']);
+	assert(lsOut.includes('METHOD') && lsOut.includes('PATH'), 'api ls shows endpoint table');
+
+	// 3. `api info` shows route details
+	const infoOut = runOrThrow(['api', 'info', '/api/v1/tests']);
+	assert(infoOut.includes('GET /api/v1/tests'), 'api info shows route method and path');
+	assert(infoOut.includes('Parameters:'), 'api info shows parameters section');
+	assert(infoOut.includes('Responses:'), 'api info shows responses section');
+
+	// 4. `api info --json` produces JSON
+	const infoJson = runOrThrow(['api', 'info', '/api/v1/tests', '--json']);
+	const parsed = JSON.parse(infoJson);
+	assert(parsed.method === 'GET', 'api info --json has correct method');
+	assert(parsed.path === '/api/v1/tests', 'api info --json has correct path');
+
+	// 5. `api examples` shows examples
+	const exOut = runOrThrow(['api', 'examples']);
+	assert(exOut.includes('API Command Examples'), 'api examples shows title');
+
+	// 6. `api openapi` shows URL
+	const oaOut = runOrThrow(['api', 'openapi']);
+	assert(oaOut.includes('/api/v1/openapi.json'), 'api openapi shows spec URL');
+
+	// 7. `api openapi --raw` dumps JSON spec
+	const oaRaw = runOrThrow(['api', 'openapi', '--raw']);
+	const spec = JSON.parse(oaRaw);
+	assert(spec.openapi && spec.paths, 'api openapi --raw returns valid OpenAPI JSON');
+});
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 

--- a/src/cli/commands/api/examples.test.ts
+++ b/src/cli/commands/api/examples.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'bun:test';
+import { examplesCommand } from './examples.js';
+
+describe('api examples command', () => {
+  it('has correct name and description', () => {
+    expect(examplesCommand.name()).toBe('examples');
+    expect(examplesCommand.description()).toBe('Show API command usage examples');
+  });
+
+  it('has no required arguments', () => {
+    expect(examplesCommand.registeredArguments.length).toBe(0);
+  });
+});

--- a/src/cli/commands/api/examples.ts
+++ b/src/cli/commands/api/examples.ts
@@ -1,0 +1,49 @@
+import { Command } from 'commander';
+
+const EXAMPLES = `
+API Command Examples
+${'─'.repeat(50)}
+
+List endpoints:
+  qa-use api ls
+  qa-use api ls --method GET
+  qa-use api ls --tag "External API v1"
+  qa-use api ls -q "tests"
+
+Make GET requests:
+  qa-use api /api/v1/tests
+  qa-use api /api/v1/tests -f limit=5
+  qa-use api /api/v1/app-configs
+
+Make POST requests:
+  qa-use api /api/v1/tests-actions/run -f test_ids='["id1"]'
+  qa-use api /api/v1/tests-actions/run --input body.json
+
+Inspect routes:
+  qa-use api info /api/v1/tests
+  qa-use api info /api/v1/tests-actions/run -X POST
+  qa-use api info /api/v1/tests --json
+
+Include response headers:
+  qa-use api /api/v1/tests --include
+
+Raw output (no formatting):
+  qa-use api /api/v1/tests --raw
+
+Custom headers:
+  qa-use api /api/v1/tests -H "X-Custom:value"
+
+OpenAPI spec:
+  qa-use api openapi
+  qa-use api openapi --raw
+
+Offline mode (use cached spec):
+  qa-use api ls --offline
+  qa-use api /api/v1/tests --offline
+`.trimStart();
+
+export const examplesCommand = new Command('examples')
+  .description('Show API command usage examples')
+  .action(() => {
+    console.log(EXAMPLES);
+  });

--- a/src/cli/commands/api/index.test.ts
+++ b/src/cli/commands/api/index.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from 'bun:test';
 import { apiCommand } from './index.js';
 
 describe('api command', () => {
-  it('registers ls as a subcommand', () => {
+  it('registers all expected subcommands', () => {
     const names = apiCommand.commands.map((command) => command.name());
     expect(names).toContain('ls');
+    expect(names).toContain('info');
+    expect(names).toContain('examples');
+    expect(names).toContain('openapi');
   });
 
   it('uses optional endpoint argument for direct requests', () => {

--- a/src/cli/commands/api/index.ts
+++ b/src/cli/commands/api/index.ts
@@ -1,5 +1,8 @@
 import { Command } from 'commander';
+import { examplesCommand } from './examples.js';
+import { infoCommand } from './info.js';
 import { lsCommand } from './ls.js';
+import { openapiCommand } from './openapi.js';
 import { registerApiRequestAction } from './request.js';
 
 export const apiCommand = registerApiRequestAction(
@@ -8,3 +11,26 @@ export const apiCommand = registerApiRequestAction(
 );
 
 apiCommand.addCommand(lsCommand);
+apiCommand.addCommand(infoCommand);
+apiCommand.addCommand(examplesCommand);
+apiCommand.addCommand(openapiCommand);
+
+apiCommand.addHelpText(
+  'after',
+  `
+Subcommands:
+  ls                     List available API endpoints
+  info <route>           Show detailed route info (input/output types)
+  examples               Show example use cases
+  openapi                Show OpenAPI spec URL (--raw for full JSON)
+
+Quick Start:
+  qa-use api ls                              List all endpoints
+  qa-use api /api/v1/tests                   GET request
+  qa-use api /api/v1/tests -X POST -f id=1   POST with field
+  qa-use api info /api/v1/tests              Route details
+  qa-use api openapi                         OpenAPI spec URL
+
+  Use "api info <route>" for detailed route input/output types.
+`
+);

--- a/src/cli/commands/api/info.test.ts
+++ b/src/cli/commands/api/info.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'bun:test';
+import { infoCommand } from './info.js';
+
+describe('api info command', () => {
+  it('defines route as a required argument', () => {
+    const args = infoCommand.registeredArguments;
+    expect(args.length).toBe(1);
+    expect(args[0].name()).toBe('route');
+    expect(args[0].required).toBe(true);
+  });
+
+  it('defines expected options', () => {
+    const optionFlags = infoCommand.options.map((option) => option.long);
+    expect(optionFlags).toContain('--method');
+    expect(optionFlags).toContain('--json');
+    expect(optionFlags).toContain('--refresh');
+    expect(optionFlags).toContain('--offline');
+  });
+});

--- a/src/cli/commands/api/info.ts
+++ b/src/cli/commands/api/info.ts
@@ -1,0 +1,70 @@
+import { Command } from 'commander';
+import { loadConfig } from '../../lib/config.js';
+import { error, formatError, warning } from '../../lib/output.js';
+import { loadOpenApiSpec, type OpenApiRefreshMode } from './lib/openapi-spec.js';
+import { renderRouteInfo } from './lib/output.js';
+import { resolveOperationCandidates } from './lib/route-matching.js';
+
+interface InfoOptions {
+  method?: string;
+  json?: boolean;
+  refresh?: boolean;
+  offline?: boolean;
+}
+
+function getRefreshMode(options: InfoOptions): OpenApiRefreshMode {
+  if (options.refresh && options.offline) {
+    throw new Error('Cannot use --refresh and --offline together');
+  }
+  if (options.refresh) return 'refresh';
+  if (options.offline) return 'offline';
+  return 'default';
+}
+
+export const infoCommand = new Command('info')
+  .description('Show detailed info for an API route (input/output types)')
+  .argument('<route>', 'API route path, e.g. /api/v1/tests')
+  .option('-X, --method <method>', 'Filter by HTTP method (GET, POST, PUT, PATCH, DELETE)')
+  .option('--json', 'Output as JSON')
+  .option('--refresh', 'Force refresh OpenAPI spec from server')
+  .option('--offline', 'Use cached OpenAPI spec only')
+  .action(async (route: string, options: InfoOptions) => {
+    try {
+      const config = await loadConfig();
+      const apiUrl = config.api_url || process.env.QA_USE_API_URL || 'https://api.desplega.ai';
+      const apiKey = config.api_key || process.env.QA_USE_API_KEY;
+      const refreshMode = getRefreshMode(options);
+
+      const openApi = await loadOpenApiSpec({
+        apiUrl,
+        apiKey,
+        refreshMode,
+        customHeaders: config.headers,
+      });
+
+      if (openApi.stale) {
+        for (const message of openApi.warnings) {
+          console.error(warning(message));
+        }
+      }
+
+      let candidates = resolveOperationCandidates(route, openApi.index.operations);
+
+      if (options.method) {
+        const expectedMethod = options.method.toUpperCase();
+        candidates = candidates.filter((op) => op.method === expectedMethod);
+      }
+
+      if (candidates.length === 0) {
+        const methodHint = options.method ? ` with method ${options.method.toUpperCase()}` : '';
+        console.log(error(`No operations found for ${route}${methodHint}`));
+        console.log('Use `qa-use api ls` to list available endpoints.');
+        process.exit(1);
+      }
+
+      console.log(renderRouteInfo(candidates, { json: options.json }));
+    } catch (err) {
+      console.error(error(`Failed to get route info: ${formatError(err)}`));
+      process.exit(1);
+    }
+  });

--- a/src/cli/commands/api/lib/openapi-spec.ts
+++ b/src/cli/commands/api/lib/openapi-spec.ts
@@ -7,24 +7,45 @@ import {
   formatStaleCacheWarning,
   OpenApiError,
 } from './openapi-errors.js';
+import { type OpenApiSchemaRef, type ResolvedSchema, resolveSchemaRef } from './schema-resolver.js';
 
 export type OpenApiRefreshMode = 'default' | 'refresh' | 'offline';
 
 interface OpenApiPathOperation {
   summary?: string;
+  description?: string;
   operationId?: string;
   tags?: string[];
   parameters?: Array<{
     name?: string;
     in?: string;
     required?: boolean;
+    description?: string;
     schema?: {
       type?: string;
     };
   }>;
   requestBody?: {
     required?: boolean;
+    content?: Record<
+      string,
+      {
+        schema?: OpenApiSchemaRef;
+      }
+    >;
   };
+  responses?: Record<
+    string,
+    {
+      description?: string;
+      content?: Record<
+        string,
+        {
+          schema?: OpenApiSchemaRef;
+        }
+      >;
+    }
+  >;
 }
 
 interface OpenApiSpecDocument {
@@ -32,7 +53,13 @@ interface OpenApiSpecDocument {
   paths: Record<string, Record<string, OpenApiPathOperation>>;
   components?: {
     securitySchemes?: Record<string, unknown>;
+    schemas?: Record<string, OpenApiSchemaRef>;
   };
+}
+
+export interface NormalizedResponseSchema {
+  description?: string;
+  schema?: ResolvedSchema;
 }
 
 export interface NormalizedOperation {
@@ -40,16 +67,20 @@ export interface NormalizedOperation {
   method: string;
   path: string;
   summary?: string;
+  description?: string;
   operationId?: string;
   tags: string[];
   parameters: Array<{
     name: string;
     in: 'path' | 'query' | 'header' | 'cookie' | 'unknown';
     required: boolean;
+    description?: string;
     schemaType?: string;
   }>;
   parameterCount: number;
   requestBodyRequired: boolean;
+  requestBodySchema?: ResolvedSchema;
+  responseSchemas?: Record<string, NormalizedResponseSchema>;
 }
 
 export interface OpenApiSpecIndex {
@@ -118,8 +149,38 @@ function validateOpenApiDocument(spec: unknown): OpenApiSpecDocument {
   return candidate as OpenApiSpecDocument;
 }
 
+function resolveRequestBodySchema(
+  op: OpenApiPathOperation,
+  componentSchemas: Record<string, OpenApiSchemaRef>
+): ResolvedSchema | undefined {
+  const content = op.requestBody?.content;
+  if (!content) return undefined;
+  const jsonContent = content['application/json'];
+  if (!jsonContent?.schema) return undefined;
+  return resolveSchemaRef(jsonContent.schema, componentSchemas);
+}
+
+function resolveResponseSchemas(
+  op: OpenApiPathOperation,
+  componentSchemas: Record<string, OpenApiSchemaRef>
+): Record<string, NormalizedResponseSchema> | undefined {
+  if (!op.responses) return undefined;
+  const result: Record<string, NormalizedResponseSchema> = {};
+  for (const [statusCode, response] of Object.entries(op.responses)) {
+    const jsonContent = response.content?.['application/json'];
+    result[statusCode] = {
+      description: response.description,
+      schema: jsonContent?.schema
+        ? resolveSchemaRef(jsonContent.schema, componentSchemas)
+        : undefined,
+    };
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
 function normalizeOperations(spec: OpenApiSpecDocument): Record<string, NormalizedOperation> {
   const operations: Record<string, NormalizedOperation> = {};
+  const componentSchemas = spec.components?.schemas || {};
 
   for (const [path, pathItem] of Object.entries(spec.paths)) {
     if (!pathItem || typeof pathItem !== 'object') {
@@ -139,6 +200,7 @@ function normalizeOperations(spec: OpenApiSpecDocument): Record<string, Normaliz
         method: normalizedMethod.toUpperCase(),
         path,
         summary: op.summary,
+        description: op.description,
         operationId: op.operationId,
         tags: Array.isArray(op.tags) ? op.tags.filter((tag) => typeof tag === 'string') : [],
         parameters: Array.isArray(op.parameters)
@@ -154,11 +216,14 @@ function normalizeOperations(spec: OpenApiSpecDocument): Record<string, Normaliz
                     ? parameter.in
                     : 'unknown',
                 required: Boolean(parameter.required),
+                description: parameter.description,
                 schemaType: parameter.schema?.type,
               }))
           : [],
         parameterCount: Array.isArray(op.parameters) ? op.parameters.length : 0,
         requestBodyRequired: Boolean(op.requestBody?.required),
+        requestBodySchema: resolveRequestBodySchema(op, componentSchemas),
+        responseSchemas: resolveResponseSchemas(op, componentSchemas),
       };
     }
   }

--- a/src/cli/commands/api/lib/output.ts
+++ b/src/cli/commands/api/lib/output.ts
@@ -1,4 +1,5 @@
-import type { NormalizedOperation } from './openapi-spec.js';
+import type { NormalizedOperation, NormalizedResponseSchema } from './openapi-spec.js';
+import type { ResolvedSchema } from './schema-resolver.js';
 
 export interface RenderListOptions {
   source: 'live' | 'cache';
@@ -50,4 +51,116 @@ export function renderOperationList(
   }
 
   return lines.join('\n');
+}
+
+export interface RenderRouteInfoOptions {
+  json?: boolean;
+}
+
+function renderSchemaProperties(schema: ResolvedSchema, indent: string): string[] {
+  const lines: string[] = [];
+  if (!schema.properties || Object.keys(schema.properties).length === 0) {
+    return lines;
+  }
+
+  const entries = Object.entries(schema.properties);
+  const nameWidth = Math.max(5, ...entries.map(([name]) => name.length));
+  const typeWidth = Math.max(4, ...entries.map(([, prop]) => prop.type.length));
+
+  lines.push(`${indent}${pad('FIELD', nameWidth)}  ${pad('TYPE', typeWidth)}  REQUIRED`);
+  lines.push(`${indent}${'-'.repeat(nameWidth)}  ${'-'.repeat(typeWidth)}  ${'-'.repeat(8)}`);
+
+  for (const [name, prop] of entries) {
+    lines.push(
+      `${indent}${pad(name, nameWidth)}  ${pad(prop.type, typeWidth)}  ${prop.required ? 'yes' : 'no'}`
+    );
+  }
+  return lines;
+}
+
+function renderResponseSchemas(
+  responses: Record<string, NormalizedResponseSchema>,
+  indent: string
+): string[] {
+  const lines: string[] = [];
+  const codes = Object.keys(responses).sort();
+  for (const code of codes) {
+    const resp = responses[code];
+    const desc = resp.description ? ` - ${resp.description}` : '';
+    lines.push(`${indent}${code}${desc}`);
+    if (resp.schema?.title) {
+      lines.push(`${indent}  Type: ${resp.schema.title}`);
+    } else if (resp.schema?.type) {
+      lines.push(`${indent}  Type: ${resp.schema.type}`);
+    }
+  }
+  return lines;
+}
+
+function renderSingleRouteInfo(op: NormalizedOperation): string[] {
+  const lines: string[] = [];
+  const indent = '  ';
+
+  lines.push(`${op.method} ${op.path}`);
+  if (op.summary) lines.push(`${indent}Summary:     ${op.summary}`);
+  if (op.description) lines.push(`${indent}Description: ${op.description}`);
+  if (op.tags.length > 0) lines.push(`${indent}Tags:        ${op.tags.join(', ')}`);
+  if (op.operationId) lines.push(`${indent}Operation:   ${op.operationId}`);
+
+  // Parameters
+  const params = op.parameters.filter((p) => p.in !== 'header');
+  lines.push('');
+  lines.push(`${indent}Parameters:`);
+  if (params.length === 0) {
+    lines.push(`${indent}  (none)`);
+  } else {
+    const nameW = Math.max(4, ...params.map((p) => p.name.length));
+    const typeW = Math.max(4, ...params.map((p) => (p.schemaType || 'string').length));
+    for (const p of params) {
+      const loc = p.in;
+      const req = p.required ? 'required' : 'optional';
+      lines.push(
+        `${indent}  ${pad(p.name, nameW)}  ${pad(p.schemaType || 'string', typeW)}  (${loc}, ${req})`
+      );
+    }
+  }
+
+  // Request body
+  if (op.requestBodySchema) {
+    const reqLabel = op.requestBodyRequired ? ' (required)' : ' (optional)';
+    lines.push('');
+    lines.push(`${indent}Request Body${reqLabel}:`);
+    if (op.requestBodySchema.title) {
+      lines.push(`${indent}  ${op.requestBodySchema.title}`);
+    }
+    const propLines = renderSchemaProperties(op.requestBodySchema, `${indent}  `);
+    if (propLines.length > 0) {
+      lines.push(...propLines);
+    }
+  }
+
+  // Responses
+  if (op.responseSchemas) {
+    lines.push('');
+    lines.push(`${indent}Responses:`);
+    lines.push(...renderResponseSchemas(op.responseSchemas, `${indent}  `));
+  }
+
+  return lines;
+}
+
+export function renderRouteInfo(
+  operations: NormalizedOperation[],
+  options: RenderRouteInfoOptions = {}
+): string {
+  if (options.json) {
+    return JSON.stringify(operations.length === 1 ? operations[0] : operations, null, 2);
+  }
+
+  if (operations.length === 0) {
+    return 'No matching operations found.';
+  }
+
+  const sections = operations.map((op) => renderSingleRouteInfo(op));
+  return sections.map((lines) => lines.join('\n')).join('\n\n');
 }

--- a/src/cli/commands/api/lib/route-matching.ts
+++ b/src/cli/commands/api/lib/route-matching.ts
@@ -1,0 +1,16 @@
+import type { NormalizedOperation } from './openapi-spec.js';
+
+export function pathTemplateToRegExp(pathTemplate: string): RegExp {
+  const escaped = pathTemplate.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = escaped.replace(/\\\{[^/]+\\\}/g, '[^/]+');
+  return new RegExp(`^${pattern}$`);
+}
+
+export function resolveOperationCandidates(
+  path: string,
+  operations: Record<string, NormalizedOperation>
+): NormalizedOperation[] {
+  return Object.values(operations).filter((operation) =>
+    pathTemplateToRegExp(operation.path).test(path)
+  );
+}

--- a/src/cli/commands/api/lib/schema-resolver.test.ts
+++ b/src/cli/commands/api/lib/schema-resolver.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from 'bun:test';
+import { formatSchemaType, type OpenApiSchemaRef, resolveSchemaRef } from './schema-resolver.js';
+
+describe('formatSchemaType', () => {
+  test('returns type for simple schemas', () => {
+    expect(formatSchemaType({ type: 'string' })).toBe('string');
+    expect(formatSchemaType({ type: 'integer' })).toBe('integer');
+    expect(formatSchemaType({ type: 'boolean' })).toBe('boolean');
+    expect(formatSchemaType({ type: 'number' })).toBe('number');
+  });
+
+  test('returns ref name for $ref schemas', () => {
+    expect(formatSchemaType({ $ref: '#/components/schemas/RunTestsRequest' })).toBe(
+      'RunTestsRequest'
+    );
+  });
+
+  test('formats array types', () => {
+    expect(formatSchemaType({ type: 'array', items: { type: 'string' } })).toBe('array<string>');
+    expect(
+      formatSchemaType({
+        type: 'array',
+        items: { $ref: '#/components/schemas/TestItem' },
+      })
+    ).toBe('array<TestItem>');
+  });
+
+  test('formats anyOf as union type', () => {
+    expect(
+      formatSchemaType({
+        anyOf: [{ type: 'string' }, { type: 'null' }],
+      })
+    ).toBe('string | null');
+  });
+
+  test('formats oneOf as union type', () => {
+    expect(
+      formatSchemaType({
+        oneOf: [{ type: 'string' }, { type: 'integer' }],
+      })
+    ).toBe('string | integer');
+  });
+
+  test('formats allOf as intersection type', () => {
+    expect(
+      formatSchemaType({
+        allOf: [{ $ref: '#/components/schemas/Base' }, { $ref: '#/components/schemas/Extended' }],
+      })
+    ).toBe('Base & Extended');
+  });
+
+  test('returns unknown for undefined or empty', () => {
+    expect(formatSchemaType(undefined)).toBe('unknown');
+    expect(formatSchemaType({})).toBe('unknown');
+  });
+});
+
+describe('resolveSchemaRef', () => {
+  const componentSchemas: Record<string, OpenApiSchemaRef> = {
+    RunTestsRequest: {
+      title: 'RunTestsRequest',
+      description: 'Request body for batch running tests',
+      type: 'object',
+      properties: {
+        test_ids: { type: 'array', items: { type: 'string' } },
+        app_config_id: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+      },
+      required: ['test_ids'],
+    },
+    TestItem: {
+      title: 'TestItem',
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+      },
+      required: ['id', 'name'],
+    },
+  };
+
+  test('resolves $ref to component schema', () => {
+    const result = resolveSchemaRef(
+      { $ref: '#/components/schemas/RunTestsRequest' },
+      componentSchemas
+    );
+    expect(result).toBeDefined();
+    expect(result!.title).toBe('RunTestsRequest');
+    expect(result!.description).toBe('Request body for batch running tests');
+    expect(result!.properties).toBeDefined();
+    expect(result!.properties!.test_ids.type).toBe('array<string>');
+    expect(result!.properties!.test_ids.required).toBe(true);
+    expect(result!.properties!.app_config_id.type).toBe('string | null');
+    expect(result!.properties!.app_config_id.required).toBe(false);
+  });
+
+  test('resolves inline schema', () => {
+    const result = resolveSchemaRef(
+      {
+        type: 'object',
+        properties: {
+          count: { type: 'integer', description: 'Total count' },
+        },
+        required: ['count'],
+      },
+      componentSchemas
+    );
+    expect(result).toBeDefined();
+    expect(result!.properties!.count.type).toBe('integer');
+    expect(result!.properties!.count.required).toBe(true);
+    expect(result!.properties!.count.description).toBe('Total count');
+  });
+
+  test('handles missing $ref target gracefully', () => {
+    const result = resolveSchemaRef({ $ref: '#/components/schemas/NonExistent' }, componentSchemas);
+    expect(result).toBeDefined();
+    expect(result!.type).toBe('NonExistent');
+    expect(result!.title).toBe('NonExistent');
+  });
+
+  test('returns undefined for undefined input', () => {
+    expect(resolveSchemaRef(undefined, componentSchemas)).toBeUndefined();
+  });
+
+  test('resolves nested $ref in properties as type name', () => {
+    const result = resolveSchemaRef(
+      {
+        type: 'object',
+        properties: {
+          items: { type: 'array', items: { $ref: '#/components/schemas/TestItem' } },
+        },
+      },
+      componentSchemas
+    );
+    expect(result!.properties!.items.type).toBe('array<TestItem>');
+  });
+
+  test('resolves allOf by merging properties', () => {
+    const result = resolveSchemaRef(
+      {
+        allOf: [
+          { $ref: '#/components/schemas/RunTestsRequest' },
+          {
+            type: 'object',
+            properties: {
+              extra_field: { type: 'boolean' },
+            },
+            required: ['extra_field'],
+          },
+        ],
+      },
+      componentSchemas
+    );
+    expect(result).toBeDefined();
+    expect(result!.properties!.test_ids).toBeDefined();
+    expect(result!.properties!.extra_field).toBeDefined();
+    expect(result!.properties!.extra_field.type).toBe('boolean');
+    expect(result!.properties!.extra_field.required).toBe(true);
+  });
+});

--- a/src/cli/commands/api/lib/schema-resolver.ts
+++ b/src/cli/commands/api/lib/schema-resolver.ts
@@ -1,0 +1,148 @@
+export interface OpenApiSchemaRef {
+  $ref?: string;
+  type?: string;
+  title?: string;
+  description?: string;
+  properties?: Record<string, OpenApiSchemaRef>;
+  items?: OpenApiSchemaRef;
+  required?: string[];
+  anyOf?: OpenApiSchemaRef[];
+  allOf?: OpenApiSchemaRef[];
+  oneOf?: OpenApiSchemaRef[];
+  additionalProperties?: boolean | OpenApiSchemaRef;
+  enum?: unknown[];
+  format?: string;
+  default?: unknown;
+}
+
+export interface ResolvedSchemaProperty {
+  type: string;
+  required: boolean;
+  description?: string;
+}
+
+export interface ResolvedSchema {
+  type?: string;
+  title?: string;
+  description?: string;
+  properties?: Record<string, ResolvedSchemaProperty>;
+}
+
+function extractRefName(ref: string): string {
+  const parts = ref.split('/');
+  return parts[parts.length - 1];
+}
+
+export function formatSchemaType(schema: OpenApiSchemaRef | undefined): string {
+  if (!schema) {
+    return 'unknown';
+  }
+
+  if (schema.$ref) {
+    return extractRefName(schema.$ref);
+  }
+
+  if (schema.anyOf) {
+    const types = schema.anyOf.map((s) => formatSchemaType(s));
+    return types.join(' | ');
+  }
+
+  if (schema.oneOf) {
+    const types = schema.oneOf.map((s) => formatSchemaType(s));
+    return types.join(' | ');
+  }
+
+  if (schema.allOf) {
+    const types = schema.allOf.map((s) => formatSchemaType(s));
+    return types.join(' & ');
+  }
+
+  if (schema.type === 'array') {
+    const itemType = schema.items ? formatSchemaType(schema.items) : 'unknown';
+    return `array<${itemType}>`;
+  }
+
+  if (schema.type) {
+    return schema.type;
+  }
+
+  return 'unknown';
+}
+
+function lookupRef(
+  ref: string,
+  componentSchemas: Record<string, OpenApiSchemaRef>
+): OpenApiSchemaRef | undefined {
+  const name = extractRefName(ref);
+  return componentSchemas[name];
+}
+
+export function resolveSchemaRef(
+  schema: OpenApiSchemaRef | undefined,
+  componentSchemas: Record<string, OpenApiSchemaRef> = {}
+): ResolvedSchema | undefined {
+  if (!schema) {
+    return undefined;
+  }
+
+  let resolved = schema;
+  if (schema.$ref) {
+    const looked = lookupRef(schema.$ref, componentSchemas);
+    if (!looked) {
+      return { type: extractRefName(schema.$ref), title: extractRefName(schema.$ref) };
+    }
+    resolved = looked;
+  }
+
+  if (resolved.allOf) {
+    return mergeAllOf(resolved.allOf, componentSchemas, resolved);
+  }
+
+  const result: ResolvedSchema = {
+    type: formatSchemaType(resolved),
+    title: resolved.title,
+    description: resolved.description,
+  };
+
+  if (resolved.properties) {
+    const requiredSet = new Set(resolved.required || []);
+    result.properties = {};
+    for (const [name, propSchema] of Object.entries(resolved.properties)) {
+      result.properties[name] = {
+        type: formatSchemaType(propSchema),
+        required: requiredSet.has(name),
+        description: propSchema.description,
+      };
+    }
+  }
+
+  return result;
+}
+
+function mergeAllOf(
+  schemas: OpenApiSchemaRef[],
+  componentSchemas: Record<string, OpenApiSchemaRef>,
+  parent: OpenApiSchemaRef
+): ResolvedSchema {
+  const merged: ResolvedSchema = {
+    type: 'object',
+    title: parent.title,
+    description: parent.description,
+    properties: {},
+  };
+
+  for (const sub of schemas) {
+    const resolved = resolveSchemaRef(sub, componentSchemas);
+    if (resolved?.properties) {
+      Object.assign(merged.properties!, resolved.properties);
+    }
+    if (!merged.title && resolved?.title) {
+      merged.title = resolved.title;
+    }
+    if (!merged.description && resolved?.description) {
+      merged.description = resolved.description;
+    }
+  }
+
+  return merged;
+}

--- a/src/cli/commands/api/openapi.test.ts
+++ b/src/cli/commands/api/openapi.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'bun:test';
+import { openapiCommand } from './openapi.js';
+
+describe('api openapi command', () => {
+  it('has correct name and description', () => {
+    expect(openapiCommand.name()).toBe('openapi');
+    expect(openapiCommand.description()).toBe('Show OpenAPI spec URL or dump full spec');
+  });
+
+  it('defines expected options', () => {
+    const optionFlags = openapiCommand.options.map((option) => option.long);
+    expect(optionFlags).toContain('--raw');
+    expect(optionFlags).toContain('--refresh');
+    expect(optionFlags).toContain('--offline');
+  });
+});

--- a/src/cli/commands/api/openapi.ts
+++ b/src/cli/commands/api/openapi.ts
@@ -1,0 +1,66 @@
+import { Command } from 'commander';
+import { loadConfig } from '../../lib/config.js';
+import { error, formatError, warning } from '../../lib/output.js';
+import { loadOpenApiSpec, type OpenApiRefreshMode } from './lib/openapi-spec.js';
+
+interface OpenApiCommandOptions {
+  raw?: boolean;
+  refresh?: boolean;
+  offline?: boolean;
+}
+
+function getRefreshMode(options: OpenApiCommandOptions): OpenApiRefreshMode {
+  if (options.refresh && options.offline) {
+    throw new Error('Cannot use --refresh and --offline together');
+  }
+  if (options.refresh) return 'refresh';
+  if (options.offline) return 'offline';
+  return 'default';
+}
+
+export const openapiCommand = new Command('openapi')
+  .description('Show OpenAPI spec URL or dump full spec')
+  .option('--raw', 'Dump full OpenAPI spec as JSON')
+  .option('--refresh', 'Force refresh spec from server')
+  .option('--offline', 'Use cached spec only')
+  .action(async (options: OpenApiCommandOptions, command: Command) => {
+    try {
+      const parentOptions = (command.parent?.opts() || {}) as OpenApiCommandOptions;
+      const effectiveOptions: OpenApiCommandOptions = {
+        ...parentOptions,
+        ...options,
+      };
+
+      const config = await loadConfig();
+      const apiUrl = (
+        config.api_url ||
+        process.env.QA_USE_API_URL ||
+        'https://api.desplega.ai'
+      ).replace(/\/$/, '');
+
+      if (!effectiveOptions.raw) {
+        console.log(`${apiUrl}/api/v1/openapi.json`);
+        return;
+      }
+
+      const apiKey = config.api_key || process.env.QA_USE_API_KEY;
+      const refreshMode = getRefreshMode(effectiveOptions);
+      const spec = await loadOpenApiSpec({
+        apiUrl,
+        apiKey,
+        refreshMode,
+        customHeaders: config.headers,
+      });
+
+      if (spec.stale) {
+        for (const message of spec.warnings) {
+          console.error(warning(message));
+        }
+      }
+
+      console.log(JSON.stringify(spec.index.raw, null, 2));
+    } catch (err) {
+      console.error(error(`Failed to load OpenAPI spec: ${formatError(err)}`));
+      process.exit(1);
+    }
+  });

--- a/src/cli/commands/api/request.ts
+++ b/src/cli/commands/api/request.ts
@@ -8,6 +8,7 @@ import {
   type NormalizedOperation,
   type OpenApiRefreshMode,
 } from './lib/openapi-spec.js';
+import { resolveOperationCandidates } from './lib/route-matching.js';
 
 interface RequestCommandOptions {
   method?: string;
@@ -57,21 +58,6 @@ function parseEndpoint(endpoint: string): { path: string; query: Record<string, 
     path: parsed.pathname,
     query,
   };
-}
-
-function pathTemplateToRegExp(pathTemplate: string): RegExp {
-  const escaped = pathTemplate.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const pattern = escaped.replace(/\\\{[^/]+\\\}/g, '[^/]+');
-  return new RegExp(`^${pattern}$`);
-}
-
-function resolveOperationCandidates(
-  path: string,
-  operations: Record<string, NormalizedOperation>
-): NormalizedOperation[] {
-  return Object.values(operations).filter((operation) =>
-    pathTemplateToRegExp(operation.path).test(path)
-  );
 }
 
 export function inferMethod(
@@ -176,12 +162,11 @@ export function registerApiRequestAction(
     .option('--raw', 'Print raw response body')
     .option('--refresh', 'Force refresh OpenAPI spec from server')
     .option('--offline', 'Use cached OpenAPI spec only')
-    .action(async (endpoint: string | undefined, options: RequestCommandOptions) => {
+    .action(async (endpoint: string | undefined, options: RequestCommandOptions, cmd: Command) => {
       try {
         if (!endpoint) {
-          throw new Error(
-            'Endpoint path is required. Use `qa-use api ls` to list available endpoints.'
-          );
+          cmd.help();
+          return;
         }
 
         const config = await loadConfig();

--- a/src/cli/commands/docs.ts
+++ b/src/cli/commands/docs.ts
@@ -23,12 +23,20 @@ function printList(): void {
     console.log(`    template:${key.padEnd(14)} ${TEMPLATES[key].title}`);
   }
 
+  console.log('\n  API:');
+  console.log(`    ${'api ls'.padEnd(22)} List available API endpoints`);
+  console.log(`    ${'api info <route>'.padEnd(22)} Route details (input/output types)`);
+  console.log(`    ${'api examples'.padEnd(22)} API usage examples`);
+  console.log(`    ${'api openapi'.padEnd(22)} OpenAPI spec URL (--raw for JSON)`);
+
   console.log(`
 Usage:
   qa-use docs                      Main documentation
   qa-use docs browser-commands     Browser commands reference
   qa-use docs templates            List all templates
-  qa-use docs template:auth-flow   Show auth flow template`);
+  qa-use docs template:auth-flow   Show auth flow template
+  qa-use api info /api/v1/tests    Route input/output types
+  qa-use api examples              API usage examples`);
 }
 
 export const docsCommand = new Command('docs')

--- a/src/cli/commands/docs.ts
+++ b/src/cli/commands/docs.ts
@@ -23,20 +23,18 @@ function printList(): void {
     console.log(`    template:${key.padEnd(14)} ${TEMPLATES[key].title}`);
   }
 
-  console.log('\n  API:');
-  console.log(`    ${'api ls'.padEnd(22)} List available API endpoints`);
-  console.log(`    ${'api info <route>'.padEnd(22)} Route details (input/output types)`);
-  console.log(`    ${'api examples'.padEnd(22)} API usage examples`);
-  console.log(`    ${'api openapi'.padEnd(22)} OpenAPI spec URL (--raw for JSON)`);
-
   console.log(`
 Usage:
   qa-use docs                      Main documentation
   qa-use docs browser-commands     Browser commands reference
   qa-use docs templates            List all templates
   qa-use docs template:auth-flow   Show auth flow template
-  qa-use api info /api/v1/tests    Route input/output types
-  qa-use api examples              API usage examples`);
+
+API Documentation (via qa-use api):
+  qa-use api ls                    List available API endpoints
+  qa-use api info <route>          Route details (input/output types)
+  qa-use api examples              API usage examples
+  qa-use api openapi               OpenAPI spec URL (--raw for JSON)`);
 }
 
 export const docsCommand = new Command('docs')

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -71,8 +71,9 @@ Command Groups:
   Setup:     setup, info, install-deps, update
   Testing:   test run, test list, test validate, test init
   Browser:   browser create, browser goto, browser snapshot, browser click
+  API:       api ls, api info, api examples, api openapi
   Docs:      docs, docs <topic>, docs --list
-  Advanced:  mcp, api
+  Advanced:  mcp
 
 Common Workflows:
   # Verify a feature in the browser
@@ -84,6 +85,11 @@ Common Workflows:
   # Create and run a test
   qa-use test init
   qa-use test run example-test
+
+  # Explore and call API endpoints
+  qa-use api ls
+  qa-use api info /api/v1/tests
+  qa-use api /api/v1/tests -f limit=5
 
   # Record a flow and generate a test
   qa-use browser create


### PR DESCRIPTION
## Summary

- Add `api info <route> [-X method] [--json]` subcommand showing route parameters, request body schema, and response types
- Add `api examples` subcommand with usage examples
- Add `api openapi [--raw]` subcommand showing OpenAPI spec URL or full JSON dump
- `api` alone now shows help instead of throwing an error
- Update `docs --list` to include API section
- New schema-resolver for `$ref`/`anyOf`/`allOf` resolution, route-matching utilities extracted for reuse
- `NormalizedOperation` extended with `requestBodySchema` and `responseSchemas`

## Test plan

- [x] 245 unit tests pass (37 in api/ alone, including new tests for info, examples, openapi, schema-resolver)
- [x] `bun run typecheck` clean
- [x] `bun run check:fix` clean
- [x] e2e Section 4 (API Subcommands) — 10 assertions pass
- [x] e2e Sections 1-2 (Browser Commands, Table Filtering) pass
- [ ] e2e Section 3 (Test Runner) — pre-existing failure: "app_config is required"