### PR TITLE
Name-collision-safe test sync pull/push (2.17.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.claude/scheduled_tasks.lock
 .mcp.json
 .env
 node_modules/

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ qa-use test run --all           # Run all tests
 
 Run `qa-use test --help` for all options.
 
+> **Filename suffix (≥ 2.17).** `pull` writes one file per cloud test as `${safe-name}-${short-id}.yaml`, where `${short-id}` is the first 8 hex chars of the test UUID. Test names can collide within an org by design, so the suffix guarantees one local file per cloud row. If you upgrade from an earlier version, the next `pull` will write new suffixed files alongside any legacy un-suffixed file you had — qa-use prints a one-line `Legacy file: …` notice per orphan and never auto-deletes. Inspect the legacy file's `id:` field; remove it manually once you've confirmed it's not load-bearing.
+
 ### Browser Commands
 
 Interactive browser control for test development and debugging:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/qa-use",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "packageManager": "bun@^1.3.4",
   "description": "QA automation tool for browser testing with MCP server support",
   "type": "module",

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -194,28 +194,32 @@ await section('Section 1: Browser Commands', () => {
 await section('Section 2: Table Filtering', () => {
 	let sessionId = '';
 
+	// Loads /table directly. The home → click("Table Demo") path triggers a
+	// React reconciliation crash under a qa-use tunneled session — see
+	// DES-356. The page itself is healthy; only client-side <Link> navigation
+	// from home crashes. Direct loads work fine and exercise the same filter
+	// regression coverage Section 2 was originally written for.
+	const TABLE_URL = `${EVALS_URL.replace(/\/?$/, '')}/table`;
+
 	try {
-		// 1. Create session
-		const createOut = runOrThrow(['browser', 'create', EVALS_URL]);
+		// 1. Create session directly on /table
+		const createOut = runOrThrow(['browser', 'create', TABLE_URL]);
 		sessionId = parseSessionId(createOut);
 
-		// 2. Navigate to Table Demo
-		runOrThrow(['browser', 'click', '--text', 'Table Demo']);
-
-		// 3. Verify table page and find filter input ref
+		// 2. Verify table page and find filter input ref
 		const snap1 = runOrThrow(['browser', 'snapshot']);
 		assert(snap1.includes('Filter by name'), 'Table page has filter input');
 		const filterRef = extractRef(snap1, /textbox.*?ref=(\w+)/);
 
-		// 4. Fill filter with "John" using ref from snapshot
+		// 3. Fill filter with "John" using ref from snapshot
 		runOrThrow(['browser', 'fill', filterRef, 'John']);
 
-		// 5. Verify filtered results
+		// 4. Verify filtered results
 		const snap2 = runOrThrow(['browser', 'snapshot']);
 		assert(snap2.includes('John Doe'), 'Filtered snapshot contains "John Doe"');
 		assert(!snap2.includes('Alice Brown'), 'Filtered snapshot does NOT contain "Alice Brown"');
 
-		// 6. Close
+		// 5. Close
 		runOrThrow(['browser', 'close']);
 		assert(true, 'Session closed');
 	} finally {

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -10,8 +10,18 @@
  */
 
 import { spawn, spawnSync } from 'node:child_process';
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	readdirSync,
+	rmSync,
+	unlinkSync,
+	writeFileSync,
+} from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 
 const EVALS_URL = 'https://evals.desplega.ai/';
@@ -1033,6 +1043,284 @@ await section('Section 16: Test Vars (imperative CLI)', () => {
 		if (existsSync(fixture)) unlinkSync(fixture);
 	}
 });
+
+// ---------------------------------------------------------------------------
+// Section 17: Test sync name-collision regression
+// ---------------------------------------------------------------------------
+//
+// Regression coverage for the duplicate-name pull/push fix:
+//   - `pull` writes one file per cloud row, suffixed with `-${shortId8}.yaml`,
+//     even when two cloud tests share the same `name`.
+//   - A legacy un-suffixed `${safeName}.yaml` left in place from older qa-use
+//     versions surfaces a one-line `Legacy file:` warning on next pull.
+//   - `push --id <colliding-name>` exits 1 with an `Ambiguous: ...` banner that
+//     names both local files and the `Use --id <uuid>` opt-out.
+//   - `push --id <uuid>` resolves to exactly one test (BC for unique-name --id).
+//
+// **Cleanup.** The public API does not expose `DELETE /api/v1/tests/{id}` — see
+// `qa-use api ls` (only POST/GET on /tests endpoints). Cleanup attempts the
+// DELETE for forward-compat and logs a warning on 405; the cloud rows are
+// named with a unique `e2e-dup-${nonce}` prefix so they're easy to reap
+// manually if they accumulate. The temp directory is always removed.
+
+await section('Section 17: Test sync name-collision regression', () => {
+	// Quick reachability probe — if we can't list tests, skip the whole section.
+	const probe = run(['api', '-X', 'GET', '/api/v1/tests', '-f', 'limit=1'], 15_000);
+	if (probe.exitCode !== 0) {
+		console.log(
+			`  SKIP: backend unreachable for /api/v1/tests probe (exit=${probe.exitCode}); cannot exercise pull/push round-trip`,
+		);
+		return;
+	}
+
+	// Section-local helper: spawn the CLI with a custom cwd so commands resolve
+	// `.qa-use.json` and `test_directory` against our temp scratch dir, not the
+	// repo root.
+	//
+	// `cmdPrefix` defaults to `bun run cli`, which resolves the `cli` script
+	// against package.json in the spawn cwd. Since the temp dir has no
+	// package.json, we translate `bun run cli` → `bun <repoRoot>/src/cli/index.ts`
+	// for this section so the CLI entry resolves regardless of cwd. For
+	// `--cmd qa-use` (or any arbitrary binary on PATH), we use cmdPrefix as-is.
+	const repoRoot = resolve(import.meta.dirname, '..');
+	function runIn(
+		cwd: string,
+		args: string[],
+		timeout = 60_000,
+	): { stdout: string; stderr: string; exitCode: number } {
+		let parts: string[];
+		if (cmdPrefix.trim() === 'bun run cli') {
+			parts = ['bun', resolve(repoRoot, 'src/cli/index.ts'), ...args];
+		} else {
+			parts = cmdPrefix.split(/\s+/).concat(args);
+		}
+		const cmd = parts[0];
+		const spawnArgs = parts.slice(1);
+		const r = spawnSync(cmd, spawnArgs, {
+			cwd,
+			encoding: 'utf-8',
+			timeout,
+			env: process.env,
+		});
+		return {
+			stdout: r.stdout ?? '',
+			stderr: r.stderr ?? '',
+			exitCode: r.status ?? 1,
+		};
+	}
+
+	// Resolve api_key + api_url from the repo's `.qa-use.json` so the temp dir
+	// inherits credentials without us re-implementing the lookup chain.
+	let repoApiKey: string | undefined;
+	let repoApiUrl: string | undefined;
+	try {
+		const repoCfg = JSON.parse(readFileSync(configPath, 'utf-8')) as {
+			api_key?: string;
+			api_url?: string;
+		};
+		repoApiKey = repoCfg.api_key;
+		repoApiUrl = repoCfg.api_url;
+	} catch (err) {
+		console.log(`  SKIP: could not parse repo .qa-use.json: ${err}`);
+		return;
+	}
+	if (!repoApiKey) {
+		console.log('  SKIP: repo .qa-use.json has no api_key');
+		return;
+	}
+
+	// Use a unique nonce so the cloud rows we create are recognizable if cleanup
+	// fails (no DELETE endpoint — best-effort only).
+	const nonce = `${Date.now().toString(36)}-${randomUUID().slice(0, 4)}`;
+	const collidingName = `e2e dup ${nonce}`;
+	const uuidA = randomUUID();
+	const uuidB = randomUUID();
+	const shortA = uuidA.replace(/-/g, '').slice(0, 8);
+	const shortB = uuidB.replace(/-/g, '').slice(0, 8);
+
+	const tmpRoot = mkdtempSync(resolve(tmpdir(), 'qa-use-e2e-collision-'));
+	const tmpQaTests = resolve(tmpRoot, 'qa-tests');
+	mkdirSync(tmpQaTests, { recursive: true });
+
+	// Plant a per-tmp `.qa-use.json` so the CLI uses our temp test_directory.
+	const tmpConfig = {
+		test_directory: './qa-tests',
+		api_key: repoApiKey,
+		api_url: repoApiUrl,
+		defaults: { headless: true, persist: false, timeout: 60 },
+	};
+	writeFileSync(
+		resolve(tmpRoot, '.qa-use.json'),
+		JSON.stringify(tmpConfig, null, 2),
+		'utf-8',
+	);
+
+	// Two YAML test files with the same `name` and pre-assigned, distinct UUIDs.
+	// Pre-assigning the UUIDs lets us deterministically assert the `-${shortId8}`
+	// filename suffix on pull without round-tripping through stdout.
+	const fileA = resolve(tmpQaTests, 'a.yaml');
+	const fileB = resolve(tmpQaTests, 'b.yaml');
+	writeFileSync(
+		fileA,
+		[
+			`id: ${uuidA}`,
+			`name: ${collidingName}`,
+			'steps:',
+			'  - action: goto',
+			'    url: https://example.com',
+			'',
+		].join('\n'),
+	);
+	writeFileSync(
+		fileB,
+		[
+			`id: ${uuidB}`,
+			`name: ${collidingName}`,
+			'steps:',
+			'  - action: goto',
+			'    url: https://example.com',
+			'',
+		].join('\n'),
+	);
+
+	let pushedA = false;
+	let pushedB = false;
+
+	try {
+		// 1. SETUP — push both YAMLs (real, not dry-run) to create two cloud rows
+		// with the same name and pre-assigned UUIDs.
+		const setupPush = runIn(tmpRoot, ['test', 'sync', 'push', '--all'], 60_000);
+		if (setupPush.exitCode !== 0) {
+			console.log(
+				`  SKIP: setup push failed (exit=${setupPush.exitCode}); cannot exercise round-trip`,
+			);
+			console.log(`    stdout: ${stripAnsi(setupPush.stdout).split('\n').slice(-5).join(' | ')}`);
+			console.log(`    stderr: ${stripAnsi(setupPush.stderr).split('\n').slice(-3).join(' | ')}`);
+			return;
+		}
+		const setupOut = stripAnsi(setupPush.stdout);
+		// Sanity: both UUIDs appear in push output (action lines reference them).
+		pushedA = setupOut.includes(uuidA);
+		pushedB = setupOut.includes(uuidB);
+		assert(pushedA && pushedB, 'Setup push created both rows with pre-assigned UUIDs');
+
+		// 2. PULL-COLLISION — clear local files, then pull. Expect two suffixed
+		// files containing the right ids.
+		unlinkSync(fileA);
+		unlinkSync(fileB);
+		const pullRes = runIn(tmpRoot, ['test', 'sync', 'pull'], 60_000);
+		assert(pullRes.exitCode === 0, 'pull (no --id) exits 0 against a populated cloud');
+
+		// Filter to only files matching our nonce-named tests so we don't
+		// trip on unrelated org tests pulled at the same time.
+		const yamlFiles = readdirSync(tmpQaTests).filter((f) => f.endsWith('.yaml'));
+		const expectedA = `${toSafeFilenameLocal(collidingName)}-${shortA}.yaml`;
+		const expectedB = `${toSafeFilenameLocal(collidingName)}-${shortB}.yaml`;
+		const hasA = yamlFiles.includes(expectedA);
+		const hasB = yamlFiles.includes(expectedB);
+		assert(hasA, `pull wrote suffixed file for uuid A: ${expectedA}`);
+		assert(hasB, `pull wrote suffixed file for uuid B: ${expectedB}`);
+
+		if (hasA) {
+			const aContent = readFileSync(resolve(tmpQaTests, expectedA), 'utf-8');
+			assert(aContent.includes(uuidA), `Pulled file A contains its UUID (${uuidA})`);
+		}
+		if (hasB) {
+			const bContent = readFileSync(resolve(tmpQaTests, expectedB), 'utf-8');
+			assert(bContent.includes(uuidB), `Pulled file B contains its UUID (${uuidB})`);
+		}
+
+		// 3. LEGACY-ORPHAN WARNING — plant the un-suffixed legacy file and pull
+		// again; expect the `Legacy file:` warning per `warnLegacyOrphan` in
+		// sync.ts.
+		const legacyName = `${toSafeFilenameLocal(collidingName)}.yaml`;
+		const legacyPath = resolve(tmpQaTests, legacyName);
+		// Plant a legacy file with one of the UUIDs so the warning's "ownership"
+		// branch ("same id — safe to remove") fires for one of the two pulled rows.
+		writeFileSync(
+			legacyPath,
+			[
+				`id: ${uuidA}`,
+				`name: ${collidingName}`,
+				'steps:',
+				"  - type: go_to",
+				'    url: https://example.com',
+				'',
+			].join('\n'),
+		);
+		const pullAgain = runIn(tmpRoot, ['test', 'sync', 'pull', '--force'], 60_000);
+		assert(pullAgain.exitCode === 0, 'pull --force re-run exits 0 with legacy file present');
+		const pullAgainOut = stripAnsi(`${pullAgain.stdout}\n${pullAgain.stderr}`);
+		assert(
+			pullAgainOut.includes(`Legacy file: ${legacyName}`),
+			`pull surfaces "Legacy file: ${legacyName}" warning`,
+		);
+		// And the file itself is preserved — qa-use never auto-deletes legacy files.
+		assert(existsSync(legacyPath), 'Legacy un-suffixed file is preserved (not auto-deleted)');
+
+		// 4. PUSH-AMBIGUITY — `push --id "<colliding-name>"` against a directory
+		// containing both YAMLs must exit 1 with the disambiguation banner.
+		// First, remove the legacy file so it doesn't trip the load (its id
+		// matches uuidA, which would still get filtered, but cleaner without it).
+		unlinkSync(legacyPath);
+		const ambig = runIn(
+			tmpRoot,
+			['test', 'sync', 'push', '--id', collidingName, '--dry-run'],
+			60_000,
+		);
+		assert(ambig.exitCode === 1, 'push --id <colliding-name> exits 1');
+		const ambigOut = stripAnsi(`${ambig.stdout}\n${ambig.stderr}`);
+		assert(/Ambiguous/.test(ambigOut), 'push --id <colliding-name> output contains "Ambiguous"');
+		assert(
+			ambigOut.includes(uuidA) && ambigOut.includes(uuidB),
+			'Ambiguous banner lists both colliding UUIDs',
+		);
+		assert(
+			/Use --id <uuid>/.test(ambigOut),
+			'Ambiguous banner mentions "Use --id <uuid>" opt-out',
+		);
+
+		// 5. PUSH-BY-UUID — disambiguates to exactly one test.
+		const single = runIn(
+			tmpRoot,
+			['test', 'sync', 'push', '--id', uuidA, '--dry-run'],
+			60_000,
+		);
+		assert(single.exitCode === 0, 'push --id <uuid> exits 0');
+		const singleOut = stripAnsi(`${single.stdout}\n${single.stderr}`);
+		assert(
+			/Found 1 matching/.test(singleOut),
+			'push --id <uuid> reports "Found 1 matching" test',
+		);
+	} finally {
+		// Best-effort cleanup. No public DELETE endpoint exists for tests today;
+		// this attempt is forward-compat — if it 405s, the cloud rows leak under
+		// recognizable names (`e2e dup <nonce>`) but the test passes.
+		for (const id of [uuidA, uuidB]) {
+			const del = run(['api', '-X', 'DELETE', `/api/v1/tests/${id}`], 15_000);
+			if (del.exitCode !== 0) {
+				const tail = stripAnsi(`${del.stdout}\n${del.stderr}`).split('\n').slice(-2).join(' | ');
+				console.log(
+					`  WARN: cleanup DELETE /api/v1/tests/${id} failed (exit=${del.exitCode}) — likely no DELETE endpoint; row leaks. ${tail}`,
+				);
+			}
+		}
+		try {
+			rmSync(tmpRoot, { recursive: true, force: true });
+		} catch {
+			// Ignore
+		}
+	}
+});
+
+// Local copy of `toSafeFilename` from src/utils/strings.ts. Inlined here to
+// avoid a TypeScript path import — scripts/e2e.ts is a top-level executable.
+function toSafeFilenameLocal(name: string, fallback = 'unnamed-test'): string {
+	return (name || fallback)
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-|-$/g, '');
+}
 
 // ---------------------------------------------------------------------------
 // Summary

--- a/src/cli/commands/test/export.ts
+++ b/src/cli/commands/test/export.ts
@@ -7,7 +7,7 @@ import * as path from 'node:path';
 import { Command } from 'commander';
 import * as yaml from 'yaml';
 import type { TestDefinition } from '../../../types/test-definition.js';
-import { toSafeFilename } from '../../../utils/strings.js';
+import { toUniqueTestFilename } from '../../../utils/strings.js';
 import { createApiClient, loadConfig } from '../../lib/config.js';
 import { error, formatError, info, success, warning } from '../../lib/output.js';
 
@@ -93,8 +93,8 @@ export const exportCommand = new Command('export')
       const written: string[] = [];
 
       for (const test of tests) {
-        const safeName = toSafeFilename(test.name || test.id || '');
-        const outputPath = path.join(testDir, safeName + ext);
+        const slug = toUniqueTestFilename(test.name || test.id || '', test.id);
+        const outputPath = path.join(testDir, slug + ext);
 
         // Serialize individual test (depends_on stays as UUID)
         const testContent =

--- a/src/cli/commands/test/list.ts
+++ b/src/cli/commands/test/list.ts
@@ -8,16 +8,10 @@ import { apiCall, paginationQuery, requireApiKey } from '../../lib/api-helpers.j
 import { loadConfig } from '../../lib/config.js';
 import { discoverTests, loadTestDefinition } from '../../lib/loader.js';
 import { error, formatError } from '../../lib/output.js';
-import {
-  type Column,
-  formatStatus,
-  formatTimestamp,
-  printTable,
-  truncate,
-} from '../../lib/table.js';
+import { type Column, formatStatus, formatTimestamp, printTable } from '../../lib/table.js';
 
 const cloudColumns: Column[] = [
-  { key: 'id', header: 'ID', width: 10, format: (v) => truncate(String(v ?? '-'), 10) },
+  { key: 'id', header: 'ID', width: 36 },
   { key: 'name', header: 'NAME' },
   { key: 'status', header: 'STATUS', format: (v) => formatStatus(String(v ?? '-')) },
   {
@@ -29,6 +23,7 @@ const cloudColumns: Column[] = [
 ];
 
 const localColumns: Column[] = [
+  { key: 'id', header: 'ID', width: 36, format: (v) => (v ? String(v) : '-') },
   { key: 'name', header: 'NAME' },
   { key: 'steps', header: 'STEPS', width: 5 },
   { key: 'deps', header: 'DEPS' },
@@ -114,6 +109,7 @@ export const listCommand = new Command('list')
               .relative(resolvedTestDir, file)
               .replace(/\.(yaml|yml|json)$/, '');
             rows.push({
+              id: def.id,
               name: relativePath,
               steps: def.steps?.length ?? '-',
               deps: def.depends_on || '-',

--- a/src/cli/commands/test/sync.test.ts
+++ b/src/cli/commands/test/sync.test.ts
@@ -6,7 +6,30 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { syncCommand, updateLocalVersionHash } from './sync.js';
+import type { TestDefinition } from '../../../types/test-definition.js';
+import {
+  filterDefinitionsByHandle,
+  findLocalForImported,
+  syncCommand,
+  updateLocalVersionHash,
+} from './sync.js';
+
+// ---------------------------------------------------------------------------
+// Test fixtures helpers
+// ---------------------------------------------------------------------------
+//
+// We only ever care about `id` + `name` for the resolution helpers under test
+// — the other TestDefinition fields are irrelevant to the disambiguation
+// logic. `mkDef` keeps each fixture line short and intent-revealing.
+function mkDef(name: string, id?: string): { def: TestDefinition; file: string } {
+  const def: TestDefinition = id
+    ? ({ name, id, steps: [] } as unknown as TestDefinition)
+    : ({ name, steps: [] } as unknown as TestDefinition);
+  // Synthesize a file path. Disambiguates entries with the same name when we
+  // assert which entry came back.
+  const file = `qa-tests/${name.toLowerCase().replace(/\s+/g, '-')}${id ? `-${id.slice(0, 4)}` : ''}.yaml`;
+  return { def, file };
+}
 
 describe('syncCommand', () => {
   describe('command structure', () => {
@@ -288,5 +311,137 @@ steps:
     const nonExistentFile = path.join(tempDir, 'does-not-exist.yaml');
 
     await expect(updateLocalVersionHash(nonExistentFile, 'hash')).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterDefinitionsByHandle
+// ---------------------------------------------------------------------------
+//
+// The `--id` handle on `qa-use test sync push` accepts either a UUID or a
+// name. UUIDs are unambiguous; names can collide. The function under test
+// returns a structured `{ matched, ambiguous }` shape — the CLI runtime
+// renders the disambiguation banner and exits 1 when `ambiguous` is true.
+// These tests pin the *resolution* contract; the banner / exit live in the
+// action handler (covered by Phase 3 e2e).
+
+describe('filterDefinitionsByHandle', () => {
+  const aaaaUuid = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa';
+  const bbbbUuid = 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb';
+
+  it('resolves a unique uuid match to one entry, no ambiguity', () => {
+    const defs = [mkDef('Login', aaaaUuid), mkDef('Logout', bbbbUuid)];
+    const result = filterDefinitionsByHandle(defs, aaaaUuid);
+    expect(result.matched).toHaveLength(1);
+    expect(result.matched[0]?.def.id).toBe(aaaaUuid);
+    expect(result.ambiguous).toBe(false);
+  });
+
+  it('resolves a unique name match to one entry, no ambiguity (BC)', () => {
+    const defs = [mkDef('Solo', aaaaUuid), mkDef('Other', bbbbUuid)];
+    const result = filterDefinitionsByHandle(defs, 'Solo');
+    expect(result.matched).toHaveLength(1);
+    expect(result.matched[0]?.def.name).toBe('Solo');
+    expect(result.ambiguous).toBe(false);
+  });
+
+  it('flags ambiguity and returns all colliding entries when a name matches ≥2 defs', () => {
+    const defs = [mkDef('Dup', aaaaUuid), mkDef('Dup', bbbbUuid), mkDef('Other', undefined)];
+    const result = filterDefinitionsByHandle(defs, 'Dup');
+    expect(result.ambiguous).toBe(true);
+    expect(result.matched).toHaveLength(2);
+    const ids = result.matched.map((m) => m.def.id);
+    expect(ids).toContain(aaaaUuid);
+    expect(ids).toContain(bbbbUuid);
+  });
+
+  it('returns 0 matches and no ambiguity when a name does not match anything', () => {
+    const defs = [mkDef('Login', aaaaUuid), mkDef('Logout', bbbbUuid)];
+    const result = filterDefinitionsByHandle(defs, 'Nope');
+    expect(result.matched).toHaveLength(0);
+    expect(result.ambiguous).toBe(false);
+  });
+
+  it('returns 0 matches and no ambiguity when a uuid does not match anything', () => {
+    const missingUuid = 'cccccccc-cccc-4ccc-cccc-cccccccccccc';
+    const defs = [mkDef('Login', aaaaUuid), mkDef('Logout', bbbbUuid)];
+    const result = filterDefinitionsByHandle(defs, missingUuid);
+    expect(result.matched).toHaveLength(0);
+    expect(result.ambiguous).toBe(false);
+  });
+
+  it('routes a uuid-shaped handle through the UUID branch — does NOT fall back to name', () => {
+    // Regression-guard: a local def whose `name` literally equals a UUID must
+    // not be picked up by the name-branch when the handle is the same UUID.
+    // The `isUuid` gate must take precedence.
+    const defs = [
+      // A def whose *name* is a uuid string but whose id is something else.
+      mkDef(aaaaUuid, bbbbUuid),
+    ];
+    const result = filterDefinitionsByHandle(defs, aaaaUuid);
+    // Routed through UUID branch → looks up by id, finds nothing.
+    expect(result.matched).toHaveLength(0);
+    expect(result.ambiguous).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findLocalForImported
+// ---------------------------------------------------------------------------
+//
+// Maps an imported result entry (always has id + name from the cloud) back to
+// its local file. Prefers id-match. Falls back to name-match only when there
+// is exactly one un-id'd local def with that name. Refuses to silently
+// mis-target — the trap case is matching a brand-new local def against an
+// imported entry whose id collides with a *different* local def by name.
+
+describe('findLocalForImported', () => {
+  const importedId = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa';
+  const otherUuid = 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb';
+
+  it('prefers id-match when local has the same id', () => {
+    const toImport = [
+      mkDef('Login', importedId), // <-- target
+      mkDef('Login'), // un-id'd same-name decoy
+      mkDef('Logout', otherUuid),
+    ];
+    const result = findLocalForImported({ id: importedId, name: 'Login' }, toImport);
+    expect(result?.def.id).toBe(importedId);
+    // Sanity: it picked the id-match, NOT the un-id'd decoy.
+    expect(result?.file).toBe(toImport[0]?.file);
+  });
+
+  it('falls back to name-match for a brand-new (un-id) local with exactly one such candidate', () => {
+    // The local def has no id (first push). The cloud assigned `importedId`.
+    // We can recover the mapping via name because exactly one un-id'd local
+    // has that name.
+    const toImport = [mkDef('NewTest'), mkDef('Other', otherUuid)];
+    const result = findLocalForImported({ id: importedId, name: 'NewTest' }, toImport);
+    expect(result?.def.name).toBe('NewTest');
+    expect(result?.def.id).toBeUndefined();
+  });
+
+  it('returns null when multiple un-id local defs share the imported name', () => {
+    const toImport = [mkDef('Dup'), mkDef('Dup'), mkDef('Other', otherUuid)];
+    const result = findLocalForImported({ id: importedId, name: 'Dup' }, toImport);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when an imported id matches nothing AND a name-only candidate has an id (the trap)', () => {
+    // The trap: imported entry has an id, but no local def has that id. There
+    // IS a local def with the same name — but it has *its own* different id.
+    // We must NOT match by name in that case (the local def represents a
+    // different cloud row). Result: null.
+    const toImport = [
+      mkDef('Login', otherUuid), // same name, different id — must not be picked
+    ];
+    const result = findLocalForImported({ id: importedId, name: 'Login' }, toImport);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when nothing matches by id or name', () => {
+    const toImport = [mkDef('Other', otherUuid)];
+    const result = findLocalForImported({ id: importedId, name: 'Login' }, toImport);
+    expect(result).toBeNull();
   });
 });

--- a/src/cli/commands/test/sync.ts
+++ b/src/cli/commands/test/sync.ts
@@ -8,7 +8,7 @@ import { Command } from 'commander';
 import * as yaml from 'yaml';
 import type { ApiClient } from '../../../../lib/api/index.js';
 import type { TestDefinition } from '../../../types/test-definition.js';
-import { toSafeFilename } from '../../../utils/strings.js';
+import { isUuid, toSafeFilename, toUniqueTestFilename } from '../../../utils/strings.js';
 import { createApiClient, loadConfig } from '../../lib/config.js';
 import { discoverTests, loadTestDefinition } from '../../lib/loader.js';
 import {
@@ -175,8 +175,8 @@ async function pullFromCloud(
     }
 
     if (dryRun) {
-      const safeName = toSafeFilename(test.name);
-      console.log(`  Would pull: ${test.name} -> ${path.join(testDir, `${safeName}.yaml`)}`);
+      const slug = toUniqueTestFilename(test.name, test.id);
+      console.log(`  Would pull: ${test.name} -> ${path.join(testDir, `${slug}.yaml`)}`);
       continue;
     }
 
@@ -195,8 +195,8 @@ async function pullFromCloud(
           continue;
         }
 
-        const safeName = toSafeFilename(testDef.name || testDef.id || '');
-        const outputPath = path.join(testDir, `${safeName}.yaml`);
+        const slug = toUniqueTestFilename(testDef.name || testDef.id || '', testDef.id);
+        const outputPath = path.join(testDir, `${slug}.yaml`);
 
         // Check if file exists
         let exists = false;
@@ -208,14 +208,22 @@ async function pullFromCloud(
         }
 
         if (exists && !force) {
-          console.log(`  Skip: ${safeName}.yaml (exists, use --force to overwrite)`);
+          console.log(`  Skip: ${slug}.yaml (exists, use --force to overwrite)`);
           skipped++;
         } else {
           // Serialize individual test (depends_on stays as UUID)
           const testContent = yaml.stringify(testDef);
           await fs.writeFile(outputPath, testContent, 'utf-8');
-          console.log(success(`  ${safeName}.yaml`));
+          console.log(success(`  ${slug}.yaml`));
           pulled++;
+        }
+
+        // Warn about orphaned legacy files (un-suffixed slug from older qa-use
+        // versions). Names can collide across rows — the legacy file may
+        // represent a different test entirely. We never auto-delete; the user
+        // disambiguates by inspecting the `id` field.
+        if (testDef.id) {
+          await warnLegacyOrphan(testDir, testDef.name || testDef.id, testDef.id);
         }
 
         if (testDef.id) {
@@ -233,6 +241,43 @@ async function pullFromCloud(
   } else {
     console.log(success(`Pulled ${pulled} test(s), skipped ${skipped}`));
   }
+}
+
+/**
+ * Warn about a legacy un-suffixed file from older qa-use versions.
+ *
+ * Pre-name-collision-fix versions wrote `${safeName}.yaml`. Now we always
+ * write `${safeName}-${shortId}.yaml`. After a fresh pull, the legacy file
+ * is left in place — it may belong to this test, or to a different test
+ * with the same name. We never auto-delete; we just nudge the user to
+ * inspect and clean up. Read the local file's `id` to make the message
+ * actionable.
+ */
+async function warnLegacyOrphan(testDir: string, testName: string, testId: string): Promise<void> {
+  const legacySlug = toSafeFilename(testName);
+  const legacyPath = path.join(testDir, `${legacySlug}.yaml`);
+  const newPath = path.join(testDir, `${toUniqueTestFilename(testName, testId)}.yaml`);
+  if (legacyPath === newPath) return;
+  try {
+    await fs.access(legacyPath);
+  } catch {
+    return;
+  }
+  let legacyId: string | undefined;
+  try {
+    const raw = await fs.readFile(legacyPath, 'utf-8');
+    const parsed = yaml.parse(raw) as { id?: string } | null;
+    legacyId = parsed?.id;
+  } catch {
+    // Unreadable / not YAML — still surface the orphan; user decides.
+  }
+  const ownership =
+    legacyId === testId
+      ? 'same id — safe to remove'
+      : legacyId
+        ? `belongs to a different test (${legacyId}) — verify before removing`
+        : 'no `id` field — verify before removing';
+  console.log(warning(`  Legacy file: ${legacySlug}.yaml (${ownership})`));
 }
 
 /**
@@ -254,8 +299,8 @@ async function writeTestsFromContent(
   let skipped = 0;
 
   for (const testDef of tests) {
-    const safeName = toSafeFilename(testDef.name || testDef.id || '');
-    const outputPath = path.join(testDir, `${safeName}.yaml`);
+    const slug = toUniqueTestFilename(testDef.name || testDef.id || '', testDef.id);
+    const outputPath = path.join(testDir, `${slug}.yaml`);
 
     // Check if file exists
     let exists = false;
@@ -267,13 +312,17 @@ async function writeTestsFromContent(
     }
 
     if (exists && !force) {
-      console.log(`  Skip: ${safeName}.yaml (exists, use --force to overwrite)`);
+      console.log(`  Skip: ${slug}.yaml (exists, use --force to overwrite)`);
       skipped++;
     } else {
       const testContent = yaml.stringify(testDef);
       await fs.writeFile(outputPath, testContent, 'utf-8');
-      console.log(success(`  ${safeName}.yaml`));
+      console.log(success(`  ${slug}.yaml`));
       pulled++;
+    }
+
+    if (testDef.id) {
+      await warnLegacyOrphan(testDir, testDef.name || testDef.id, testDef.id);
     }
   }
 
@@ -358,10 +407,30 @@ async function pushToCloud(
     return;
   }
 
-  // Filter to single test if --id provided
+  // Filter to single test if --id provided.
+  //
+  // A UUID-shaped --id is unambiguous (test ids are unique). A name-shaped
+  // --id is a convenience: it works only when exactly one local test
+  // matches that name. Names can collide by design — if the local test
+  // directory has multiple files with the same `name`, refuse the operation
+  // and ask the user to disambiguate by UUID.
   let toImport = definitions;
   if (testId) {
-    toImport = definitions.filter((d) => d.def.id === testId || d.def.name === testId);
+    if (isUuid(testId)) {
+      toImport = definitions.filter((d) => d.def.id === testId);
+    } else {
+      toImport = definitions.filter((d) => d.def.name === testId);
+      if (toImport.length > 1) {
+        console.log(error(`Ambiguous: '${testId}' matches ${toImport.length} local tests by name`));
+        for (const d of toImport) {
+          const rel = path.relative(testDir, d.file);
+          console.log(`  - ${d.def.id ?? '<no-id>'}  (${rel})`);
+        }
+        console.log('');
+        console.log('  Names can collide. Use --id <uuid> to disambiguate.');
+        process.exit(1);
+      }
+    }
     if (toImport.length === 0) {
       console.log(error(`Test not found: ${testId}`));
       console.log('  Searched by ID and name in local test files');
@@ -404,6 +473,35 @@ async function pushToCloud(
 }
 
 /**
+ * Map an imported result entry back to its local file safely.
+ *
+ * Names can collide within an org by design (Test.matrix is JSONB on a single
+ * row, so multiple rows legitimately share a `name`). The previous
+ * `id || name` fallback could silently target the wrong local file:
+ *
+ * 1. **Prefer id-match.** When the local def already has an id, that id is
+ *    unambiguous — match on it first.
+ * 2. **Fall back to name-match only for brand-new defs.** A first-push def
+ *    has no local id; the cloud has assigned one. We can still recover the
+ *    mapping via name, but only when exactly one local def with that name
+ *    has no id. If two un-id'd locals share a name, we refuse rather than
+ *    pick the wrong one.
+ *
+ * Callers handle the `null` case explicitly (skip conflict-path push, log a
+ * warning before version_hash writeback, etc.).
+ */
+function findLocalForImported(
+  imported: { id: string; name: string },
+  toImport: ReadonlyArray<{ def: TestDefinition; file: string }>
+): { def: TestDefinition; file: string } | null {
+  const byId = toImport.find((d) => d.def.id === imported.id);
+  if (byId) return byId;
+  const candidates = toImport.filter((d) => !d.def.id && d.def.name === imported.name);
+  if (candidates.length === 1) return candidates[0];
+  return null;
+}
+
+/**
  * Render the result of an importTestDefinition call: print per-test action
  * summary, refresh local version_hash, and surface conflicts/errors.
  *
@@ -435,9 +533,7 @@ export async function renderImportResult(
         break;
       case 'conflict': {
         console.log(warning(`  CONFLICT: ${imported.name} - ${imported.message}`));
-        const localDef = toImport.find(
-          (d) => d.def.id === imported.id || d.def.name === imported.name
-        );
+        const localDef = findLocalForImported(imported, toImport);
         if (localDef) {
           const relPath = path.relative(testDir, localDef.file);
           const nameWithoutExt = relPath.replace(/\.(yaml|yml|json)$/, '');
@@ -454,17 +550,21 @@ export async function renderImportResult(
   // Update local files with new version_hash after successful push
   for (const imported of result.imported) {
     if (imported.version_hash && (imported.action === 'created' || imported.action === 'updated')) {
-      const localDef = toImport.find(
-        (d) => d.def.id === imported.id || d.def.name === imported.name
-      );
-      if (localDef) {
-        try {
-          await updateLocalVersionHash(localDef.file, imported.version_hash);
-        } catch (err) {
-          console.log(
-            warning(`  Failed to update version_hash in ${localDef.file}: ${formatError(err)}`)
-          );
-        }
+      const localDef = findLocalForImported(imported, toImport);
+      if (!localDef) {
+        console.log(
+          warning(
+            `  Could not unambiguously map imported '${imported.name}' back to a local file — version_hash not updated. Pull or push by --id <uuid> to resolve.`
+          )
+        );
+        continue;
+      }
+      try {
+        await updateLocalVersionHash(localDef.file, imported.version_hash);
+      } catch (err) {
+        console.log(
+          warning(`  Failed to update version_hash in ${localDef.file}: ${formatError(err)}`)
+        );
       }
     }
   }

--- a/src/cli/commands/test/sync.ts
+++ b/src/cli/commands/test/sync.ts
@@ -348,6 +348,36 @@ interface PushOptions {
 }
 
 /**
+ * Filter loaded definitions by a `--id` handle.
+ *
+ * The push CLI accepts either a UUID or a name as `--id`. UUIDs are
+ * unambiguous (test ids are unique by construction); names are NOT — multiple
+ * Test rows can legitimately share a `name`. This function returns:
+ *
+ *   - `matched`: the local defs that match the handle (0, 1, or N entries).
+ *   - `ambiguous`: true iff the handle was a *name* and matched ≥2 local defs.
+ *     Callers render the disambiguation banner and exit 1 in that case.
+ *
+ * `ambiguous` is **never** set on the UUID branch — even if some pathological
+ * test row had a duplicate UUID, that's a backend invariant violation, not a
+ * client-side handle-resolution problem. Likewise, an empty `matched` array
+ * is not "ambiguous"; callers print a "not found" error in that case.
+ *
+ * @internal Exported for testing; the action handler in `pushToCloud` is the
+ * only production caller.
+ */
+export function filterDefinitionsByHandle(
+  definitions: ReadonlyArray<{ def: TestDefinition; file: string }>,
+  testId: string
+): { matched: Array<{ def: TestDefinition; file: string }>; ambiguous: boolean } {
+  if (isUuid(testId)) {
+    return { matched: definitions.filter((d) => d.def.id === testId), ambiguous: false };
+  }
+  const matched = definitions.filter((d) => d.def.name === testId);
+  return { matched, ambiguous: matched.length > 1 };
+}
+
+/**
  * Present-tense verb for dry-run "Would <verb>: <name>" lines.
  *
  * `ImportedTest.action` values are past tense (created, updated…) because
@@ -416,26 +446,23 @@ async function pushToCloud(
   // and ask the user to disambiguate by UUID.
   let toImport = definitions;
   if (testId) {
-    if (isUuid(testId)) {
-      toImport = definitions.filter((d) => d.def.id === testId);
-    } else {
-      toImport = definitions.filter((d) => d.def.name === testId);
-      if (toImport.length > 1) {
-        console.log(error(`Ambiguous: '${testId}' matches ${toImport.length} local tests by name`));
-        for (const d of toImport) {
-          const rel = path.relative(testDir, d.file);
-          console.log(`  - ${d.def.id ?? '<no-id>'}  (${rel})`);
-        }
-        console.log('');
-        console.log('  Names can collide. Use --id <uuid> to disambiguate.');
-        process.exit(1);
+    const { matched, ambiguous } = filterDefinitionsByHandle(definitions, testId);
+    if (ambiguous) {
+      console.log(error(`Ambiguous: '${testId}' matches ${matched.length} local tests by name`));
+      for (const d of matched) {
+        const rel = path.relative(testDir, d.file);
+        console.log(`  - ${d.def.id ?? '<no-id>'}  (${rel})`);
       }
+      console.log('');
+      console.log('  Names can collide. Use --id <uuid> to disambiguate.');
+      process.exit(1);
     }
-    if (toImport.length === 0) {
+    if (matched.length === 0) {
       console.log(error(`Test not found: ${testId}`));
       console.log('  Searched by ID and name in local test files');
       process.exit(1);
     }
+    toImport = matched;
     console.log(`Found ${toImport.length} matching test(s)\n`);
   } else {
     console.log(`Found ${definitions.length} local test(s)\n`);
@@ -489,8 +516,11 @@ async function pushToCloud(
  *
  * Callers handle the `null` case explicitly (skip conflict-path push, log a
  * warning before version_hash writeback, etc.).
+ *
+ * @internal Exported for testing; callers in this module are the only
+ * production consumers.
  */
-function findLocalForImported(
+export function findLocalForImported(
   imported: { id: string; name: string },
   toImport: ReadonlyArray<{ def: TestDefinition; file: string }>
 ): { def: TestDefinition; file: string } | null {

--- a/src/utils/strings.test.ts
+++ b/src/utils/strings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { toSafeFilename } from './strings.js';
+import { isUuid, toSafeFilename, toUniqueTestFilename } from './strings.js';
 
 describe('toSafeFilename', () => {
   test('converts name to lowercase', () => {
@@ -23,5 +23,58 @@ describe('toSafeFilename', () => {
 
   test('handles complex test names', () => {
     expect(toSafeFilename('Login Flow: Admin User (v2)')).toBe('login-flow-admin-user-v2');
+  });
+});
+
+describe('toUniqueTestFilename', () => {
+  test('appends 8-char hex prefix from UUID', () => {
+    expect(toUniqueTestFilename('Verify EASM', '275282ed-d6d8-4f16-b5c0-2645ab968789')).toBe(
+      'verify-easm-275282ed'
+    );
+  });
+
+  test('disambiguates same-named tests', () => {
+    const a = toUniqueTestFilename('Same Name', '275282ed-d6d8-4f16-b5c0-2645ab968789');
+    const b = toUniqueTestFilename('Same Name', '64b70f65-5774-47cf-b236-616f5bb17cbb');
+    expect(a).not.toBe(b);
+    expect(a).toBe('same-name-275282ed');
+    expect(b).toBe('same-name-64b70f65');
+  });
+
+  test('falls back to safe-name when id is missing', () => {
+    expect(toUniqueTestFilename('No ID', null)).toBe('no-id');
+    expect(toUniqueTestFilename('No ID', undefined)).toBe('no-id');
+    expect(toUniqueTestFilename('No ID', '')).toBe('no-id');
+  });
+
+  test('handles ids without hyphens', () => {
+    expect(toUniqueTestFilename('Compact', '275282edd6d84f16b5c02645ab968789')).toBe(
+      'compact-275282ed'
+    );
+  });
+
+  test('uses fallback slug when name is empty', () => {
+    expect(toUniqueTestFilename('', '275282ed-d6d8-4f16-b5c0-2645ab968789')).toBe(
+      'unnamed-test-275282ed'
+    );
+  });
+});
+
+describe('isUuid', () => {
+  test('accepts canonical hyphenated UUIDs', () => {
+    expect(isUuid('275282ed-d6d8-4f16-b5c0-2645ab968789')).toBe(true);
+    expect(isUuid('00000000-0000-0000-0000-000000000000')).toBe(true);
+  });
+
+  test('is case-insensitive', () => {
+    expect(isUuid('275282ED-D6D8-4F16-B5C0-2645AB968789')).toBe(true);
+  });
+
+  test('rejects non-UUID values', () => {
+    expect(isUuid('not-a-uuid')).toBe(false);
+    expect(isUuid('Verify EASM')).toBe(false);
+    expect(isUuid('275282edd6d84f164b5c02645ab968789')).toBe(false); // no hyphens
+    expect(isUuid('275282ed-d6d8-4f16-b5c0')).toBe(false); // truncated
+    expect(isUuid('')).toBe(false);
   });
 });

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -10,3 +10,33 @@ export function toSafeFilename(name: string, fallback = 'unnamed-test'): string 
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-|-$/g, '');
 }
+
+/**
+ * Build a unique filename slug for a cloud test.
+ *
+ * Test names can collide within an org — multiple Test rows may share the
+ * same `name` by design. To avoid filesystem collisions on `pull`, we always
+ * suffix the safe-name slug with a short prefix of the test UUID.
+ *
+ * Returns just the slug (no extension); callers add `.yaml` / `.json`.
+ *
+ * @example toUniqueTestFilename("Verify EASM", "275282ed-d6d8-…") → "verify-easm-275282ed"
+ */
+export function toUniqueTestFilename(name: string, id: string | undefined | null): string {
+  const safeName = toSafeFilename(name || '');
+  if (!id) return safeName;
+  const shortId = id.replace(/-/g, '').slice(0, 8);
+  return shortId ? `${safeName}-${shortId}` : safeName;
+}
+
+/**
+ * Test whether a string looks like a canonical UUID (v4-ish, hyphenated).
+ *
+ * Used to disambiguate between `--id <uuid>` and `--id <name>` in commands
+ * that accept either. A name that happens to match this shape is
+ * indistinguishable from a UUID — but names containing whitespace or `:` /
+ * special chars (the common case in this product) won't trigger.
+ */
+export function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+}

--- a/thoughts/taras/plans/2026-05-07-name-collision-safe-test-sync.md
+++ b/thoughts/taras/plans/2026-05-07-name-collision-safe-test-sync.md
@@ -1,0 +1,284 @@
+---
+status: completed
+---
+
+# qa-use — name-collision-safe `test sync pull` / `test sync push`
+
+## Context
+
+**Why this change is being made.** Test names are not unique within an org by design — `Test.matrix` is JSONB on a single row, so multiple rows can legitimately share a `name`. The CLI was written under the wrong assumption that `name` is a usable handle:
+
+1. **Pull collision (silent data loss).** `pullFromCloud` writes `${toSafeFilename(test.name)}.yaml`. With same-named cloud rows, the first written wins (skip-on-exist) or the last written wins (`--force`). A user with N same-named cloud tests ended up with a single local YAML representing one row, and no warning. Reported in prod (`org_33kGskJBHht2crEN6QXhYfXSU16`, "Verify EASM Assets Monitoring Dashboard Functionality" × 6 rows). Diagnosis: `cope/thoughts/shared/learnings/2026-05-07-taras-verify-data-model-before-bug-framing.md`.
+2. **Push ambiguity (silent wrong-target).** `push --id <x>` matches `d.def.id === x || d.def.name === x`. When multiple local defs share `name === x`, both got pushed — potentially overwriting a different cloud row than the user intended.
+3. **Post-import lookup ambiguity (silent wrong file).** After `push`, the CLI maps each imported result back to its local file by `id || name` to print conflict paths and update `version_hash`. Same collision risk: wrong local file gets its `version_hash` updated.
+
+**Outcome.** Pull writes one file per cloud row, suffixed with the first 8 hex chars of the test UUID. Push by name fails loudly when the local directory has a name collision. Post-import lookup prefers id-match and refuses to silently mis-target on name-only ambiguity. Legacy un-suffixed files are flagged on next pull but never auto-deleted.
+
+## Working draft audit (before this plan)
+
+The repo has a staged working draft (4 files, ~169 ins / 17 del) that addresses items (1) and (2) above. The plan **adopts the staged draft as-is** and adds the missing third fix plus tests, e2e coverage, and release plumbing.
+
+| Site | Sub-agent finding | Decision |
+|---|---|---|
+| `src/utils/strings.ts` `toUniqueTestFilename` / `isUuid` | New helpers | **Adopt** |
+| `src/utils/strings.test.ts` 12-case suite | Unit coverage of helpers | **Adopt** |
+| `src/cli/commands/test/sync.ts` pull (3 write sites) | Switched to `toUniqueTestFilename` | **Adopt** |
+| `src/cli/commands/test/sync.ts` `warnLegacyOrphan` | Warn-only on legacy un-suffixed files | **Adopt** (warn-only is the right call — see "Filename migration" below) |
+| `src/cli/commands/test/sync.ts` push `--id` resolution | UUID-gated; multi-match name → exit 1 | **Adopt** |
+| `src/cli/commands/test/sync.ts` `renderImportResult` lines 508 + 527 | **Still buggy** — name fallback after `id` match | **Fix in Phase 1** |
+| `src/cli/commands/test/export.ts` | Switched to `toUniqueTestFilename` | **Adopt** |
+
+### Other name-vs-id resolution sites — coherence audit
+
+Sub-agents searched `src/cli/commands/`, `src/cli/lib/`, `src/server.ts`, `src/http-server.ts`, `lib/api/`. Findings:
+
+- **Safe (no change needed):**
+  - `info.ts:238–319` — uses `UUID_RE.test(lookupKey)` to gate; name path resolves by file basename, not data field.
+  - `diff.ts` — takes a file path argument, not a handle.
+  - `run.ts` / `validate.ts` — resolve via `loadTestWithDeps` → `resolveTestPath(name, dir)`, file-path-based, not data-field-based. First-extension-wins is acceptable.
+  - `vars/set.ts` — already enforces full UUID via `isFullUuid(id)`.
+  - `runs/list.ts:44` — exact-name filter on cloud results, already errors explicitly on multi-match.
+  - **MCP server tools** (`server.ts:709/824/861/885`) and HTTP transport (`http-server.ts`) — all delegate to backend API as-is, no client-side name filtering. Backend owns disambiguation. Out of scope for this PR.
+- **Newly identified (Phase 1):** `sync.ts:508` and `sync.ts:527` — post-import map-back. The name fallback is load-bearing for first-push (local def has no id), so we can't just remove it; we tighten it instead. See Phase 1 design.
+
+### Decisions on the open questions
+
+| Question | Decision | Rationale |
+|---|---|---|
+| 8-char id-prefix collision (~1/4B per pair, same name) | Accept; document; existing skip-on-exist semantics still apply | Cost of a longer prefix is uglier filenames forever; the org-scale collision math is generous |
+| BC for `--id <unique-name>` | **Keep.** Single-match by name still works | Removes a genuine convenience with no safety win — if exactly one local file has that name, the operation is unambiguous |
+| Filename migration on pull (rename in place when legacy id matches new id) | **Reject.** Warn-only stays | Auto-rename is one extra side-effect on a sync command; the user might have unsaved local changes; warn is one-shot and the user `mv`s themselves. No `migrate-filenames` subcommand either — YAGNI until users ask |
+| Version bump | **2.17.0** | User-visible filename change in every existing `qa-tests/`. No code consumers break (paths still resolve, YAML content unchanged), so minor — not patch, not major |
+| Out of scope | Matrix/typed-variables CLI (already in 2.16.0); backend export endpoint (correct as-is); UI grouping by name; argus template version pin in `cope/be/argus-template/build-template.py` (separate downstream task) | All flagged in the original prompt; not in this PR |
+
+---
+
+## Phase 1: Tighten post-import lookup + finalize working draft
+
+**Deliverable.** A single committable bundle: the staged working draft plus a fix to `renderImportResult` so it prefers id-match and refuses to silently mis-target on name collisions.
+
+**Critical files.**
+- `src/cli/commands/test/sync.ts` — lines 505–540 (`renderImportResult`)
+
+**Design.** Replace the two `find` calls at `sync.ts:508` and `sync.ts:527` with a shared helper:
+
+```ts
+function findLocalForImported(
+  imported: { id: string; name: string },
+  toImport: ReadonlyArray<{ def: TestDefinition; file: string }>,
+): { def: TestDefinition; file: string } | null {
+  // Prefer id-match — unambiguous when the local def already has an id.
+  const byId = toImport.find((d) => d.def.id === imported.id);
+  if (byId) return byId;
+  // Fallback: local def is brand-new (no id) — match by name, but only
+  // if exactly one local def with that name has no id. Otherwise refuse.
+  const candidates = toImport.filter((d) => !d.def.id && d.def.name === imported.name);
+  if (candidates.length === 1) return candidates[0];
+  return null;
+}
+```
+
+Call sites:
+- Conflict path printing (existing line 510 if-block) — when `null`, skip the conflict-path push (still print the `CONFLICT` banner).
+- `version_hash` writeback (existing line 529 if-block) — when `null`, log `warning(...)` ("Could not unambiguously map imported '${name}' back to a local file — version_hash not updated. Pull or push by --id <uuid> to resolve.") and continue.
+
+Never silently pick the wrong file.
+
+### Success Criteria
+
+#### Automated Verification
+- [x] `bun run typecheck` passes
+- [x] `bun run check:fix` produces no diff
+- [x] `bun test src/utils/strings.test.ts` passes (44/44 from working draft, unchanged)
+
+#### Automated QA
+- [x] `bun run cli test sync push --help` lists `--id <id-or-name>` (BC preserved)
+- [x] In a temp `qa-tests/` with two YAML files sharing `name: "Dup"` and no `id` field: `bun run cli test sync push --id Dup --dry-run` exits 1 and prints `Ambiguous: 'Dup' matches 2 local tests by name` followed by the two file paths and `Use --id <uuid> to disambiguate.` (covered by working draft)
+- [x] In the same dir with one YAML having `name: "Solo"` and `id: <uuid>`: `bun run cli test sync push --id Solo --dry-run` resolves to that one test (BC for unique-name `--id`)
+
+#### Manual Verification
+- [x] Eyeball the diff for `findLocalForImported` to confirm the no-id-fallback branch matches the design exactly (the trap is matching a brand-new local def against an existing-id imported entry — the helper must not do that)
+
+---
+
+## Phase 2: Behavioral tests for push ambiguity
+
+**Deliverable.** New `bun:test` cases in `src/cli/commands/test/sync.test.ts` (currently structural-only, 293 lines) that assert the push-by-name disambiguation behavior end-to-end at the function level.
+
+**Critical files.**
+- `src/cli/commands/test/sync.test.ts`
+- Reuse `spyOn` pattern from `src/cli/lib/api-helpers.test.ts:14–27` (mocks `process.exit` and `console.log` via `bun:test` `spyOn`)
+- Reuse dependency-injection pattern from `src/cli/lib/cli-entry.test.ts:14–27` where viable
+
+**Approach.** The push action handler in `sync.ts` is a closure over `Command`, so it isn't directly callable. Two options:
+
+1. **Refactor minimal seam.** Extract the "filter `definitions` by `--id`" block into an exported pure function `filterDefinitionsByHandle(definitions, testId): { matched, ambiguous }`. Test the pure function directly. **Recommended** — surgical, no fixture juggling, exact intent.
+2. **Spawn the CLI under test.** Use `Bun.spawn` against `bun run cli test sync push --id Dup --dry-run` with a temp `qa-tests/` dir. Heavier, slower, but exercises the whole path. Already covered in Phase 3 e2e.
+
+Phase 2 implements option 1. Cases:
+
+- `unique uuid match` → 1 result, no ambiguity flag
+- `unique name match` → 1 result, no ambiguity flag (BC)
+- `colliding name match (n=2)` → ambiguity flag set, both files in result for caller to render
+- `name match with no result` → 0 results, no ambiguity flag
+- `uuid that happens to look like a name` → routes through UUID branch; no name fallback (regression-guards the `isUuid` gate)
+
+Also add tests for `findLocalForImported` from Phase 1 — same file, separate `describe` block.
+
+### Success Criteria
+
+#### Automated Verification
+- [x] `bun test src/cli/commands/test/sync.test.ts` passes including the new cases
+- [x] `bun test` (full suite) passes
+- [x] `bun run typecheck` passes
+- [x] `bun run check:fix` produces no diff
+
+#### Automated QA
+- [x] New tests assert exit-code-equivalent behavior via the pure function's return shape (no `process.exit` reliance in unit tests — that lives in the action handler)
+
+#### Manual Verification
+- [x] Confirm the extracted `filterDefinitionsByHandle` is internally consistent with the action-handler usage in `sync.ts` (no behavior drift between unit-tested function and CLI runtime)
+
+---
+
+## Phase 3: E2E regression coverage
+
+**Deliverable.** A new section in `scripts/e2e.ts` (after Section 15) that exercises duplicate-name pull and push against a real backend. Gated to skip safely if backend isn't reachable.
+
+**Critical files.**
+- `scripts/e2e.ts` — add section, follow existing banner style (`// ============== Section N: ... ==============`)
+
+**Approach.** The e2e script already has fixtures for `qa-tests/e2e.yaml`. Add:
+
+1. **Setup**: in a temp dir, write two YAML files with the same `name` ("e2e dup") and different `id` UUIDs. Push both.
+2. **Pull-collision regression**:
+   - `qa-use test sync pull --all --dir <tmp>` — assert two files exist, both suffixed with `-${shortId}`, both contain the right `id`.
+   - With a legacy un-suffixed `e2e-dup.yaml` planted in `<tmp>` first, pull again and assert the warning text appears in stdout (`Legacy file: e2e-dup.yaml (...)`).
+3. **Push-ambiguity regression**:
+   - From a `<tmp>` containing both YAMLs, run `qa-use test sync push --id "e2e dup" --dry-run` — assert exit code 1 and stderr/stdout contains `Ambiguous` plus both file relative paths plus `Use --id <uuid>`.
+   - `qa-use test sync push --id <uuid-1> --dry-run` — assert exits 0 and references exactly one test.
+4. **Cleanup**: delete both cloud test rows.
+
+Use the same `qa-use api` action calls already used elsewhere in `e2e.ts` for the cloud setup/teardown to avoid coupling to internals.
+
+### Success Criteria
+
+#### Automated Verification
+- [x] `bun run scripts/e2e.ts` runs the new section to completion against a configured backend
+- [ ] `bun run scripts/e2e.ts --cmd qa-use` runs the same against an installed binary
+
+#### Automated QA
+- [x] Section banner follows existing convention
+- [x] Gated remote-tunnel sections still skip safely when backend unreachable (regression for existing skip behavior)
+
+#### Manual Verification
+- [ ] Run the full e2e once against `localhost:5005` and confirm the new section's output matches the design (no `undefined: undefined`, exit codes correct)
+
+---
+
+## Phase 4: Version bump + README migration note
+
+**Deliverable.** `package.json` bumped to `2.17.0`; README has a short migration callout under the test-sync section.
+
+**Critical files.**
+- `package.json` — line 3, `"version": "2.16.0"` → `"version": "2.17.0"`
+- `README.md` — under `## CLI Reference > ### Test Commands` (line 57), append a short paragraph after the `test sync pull` description
+
+**README copy** (drop-in, ~6 lines):
+
+> **Filename suffix (≥ 2.17).** `pull` writes one file per cloud test as `${safe-name}-${short-id}.yaml`, where `${short-id}` is the first 8 hex chars of the test UUID. Test names can collide within an org by design, so the suffix guarantees one local file per cloud row. If you upgrade from an earlier version, the next `pull` will write new suffixed files alongside any legacy un-suffixed file you had — qa-use prints a one-line `Legacy file: …` notice per orphan and never auto-deletes. Inspect the legacy file's `id:` field; remove it manually once you've confirmed it's not load-bearing.
+
+No CHANGELOG.md exists in this repo today — the version bump speaks for itself; README + commit message carry the human-facing change description.
+
+### Success Criteria
+
+#### Automated Verification
+- [x] `bun run typecheck` passes
+- [x] `bun run check:fix` produces no diff
+- [x] `node -e "console.log(require('./package.json').version)"` prints `2.17.0`
+
+#### Automated QA
+- [x] `bun run cli --version` (or equivalent) prints `2.17.0` after `bun run build`
+
+#### Manual Verification
+- [x] Read the README diff; confirm the migration note reads cleanly to a user who has never seen the old behavior
+- [ ] Note in the PR description that **bumping argus templates** (`cope/be/argus-template/build-template.py`) is a follow-up downstream task, not in this PR
+
+---
+
+## Deviations encountered during implementation
+
+Captured here so the PR description and any follow-up planning have one source of truth.
+
+### Phase 3 — `scripts/e2e.ts` Section 17
+
+| # | Plan said | Reality | Resolution |
+|---|---|---|---|
+| 1 | `qa-use test sync pull --all --dir <tmp>` | `pull` has no `--dir` and no `--all` flag — pull pulls all by default; `test_directory` is sourced from `.qa-use.json` | Section 17 plants a per-tmp `.qa-use.json` (api_key/api_url copied from repo config; `test_directory: ./qa-tests`) and spawns the CLI with `cwd: <tmp>`. `bun run cli` had to be expanded to an absolute `bun <repoRoot>/src/cli/index.ts` because `bun run <script>` requires `package.json` in cwd |
+| 2 | `qa-use api -X DELETE /api/v1/tests/<uuid>` for cleanup | Public API exposes no DELETE on `/api/v1/tests/{id}` — backend returns `405 Method Not Allowed`, `Allow: GET` | Section 17 cleanup is best-effort: still attempts DELETE for forward-compat (logs a single-line WARN on 405) and namespaces the colliding test name with a per-run nonce (`e2e dup ${ms-base36}-${random4}`) so leaked rows are recognizable in the cloud and can be reaped manually. **Backend follow-up:** add `DELETE /api/v1/tests/{id}` (or admin-namespaced equivalent). Each run leaks 2 rows under that distinctive prefix |
+| 3 | Step shape `{ type: "go_to", url: ... }` in the YAML fixture | Schema's SimpleStep uses `{ action: "goto", target: "..." }` (no `type:` enum besides `'simple'`/`'extended'`) | Fixed inline in Section 17's fixture |
+
+### Phase 3 — `--cmd qa-use` success criterion
+
+The `bun run scripts/e2e.ts --cmd qa-use` criterion will fail until `2.17.0` is published and the user re-installs the binary (currently `2.16.0` on PATH). **Will be satisfied post-merge / publish.**
+
+### Plan's Manual E2E section (this file)
+
+The recipe at the bottom of this plan still references `qa-use api -X DELETE /api/v1/tests/<uuid>` for cleanup — same 405 issue as Section 17. If you run the Manual E2E recipe, expect step 7 to log a 405 warning. Reap leaked rows manually until the backend grows a DELETE endpoint.
+
+### CLAUDE.md drift (separate from this plan)
+
+The repo `CLAUDE.md` claims `.qa-use.json` is "pre-configured with `localhost:5005`". The actual file at the time of implementation pointed at `https://api.desplega.ai`. Section 17 ran successfully against the configured backend. **Not in scope** for this PR — flagging so the next person editing `CLAUDE.md` can either update the comment or re-point `.qa-use.json` to localhost.
+
+### Phase 1 — minor cosmetic
+
+Plan criterion says `bun run cli test sync push --help` should list `--id <id-or-name>`. Working draft has `--id <uuid>` as the metavar. Functional BC for unique-name `--id` is preserved (covered by Phase 1 QA + Phase 2 unit tests). The metavar wasn't updated this PR — cosmetic, can be fixed in a follow-up if the team wants the help text to advertise the name-fallback.
+
+---
+
+## Manual E2E
+
+After all phases land, run end-to-end against a real backend (`localhost:5005` from the repo's `.qa-use.json`). Substitute real UUIDs for `<uuid-1>` / `<uuid-2>`.
+
+```bash
+# 0. Build + lint hygiene
+bun install
+bun run check:fix
+bun run typecheck
+bun test
+
+# 1. Create two cloud tests with the same name (use existing prod data,
+#    or create via API).
+bun run cli api -X POST /api/v1/tests --input - <<'JSON'
+{ "name": "PR-collision-test", "steps": [{ "type": "go_to", "url": "https://example.com" }] }
+JSON
+# Repeat for a second test row with the same name; record both UUIDs.
+
+# 2. Pull into a clean dir; expect two suffixed files, no clobber.
+mkdir /tmp/qa-collision && cd /tmp/qa-collision
+qa-use test sync pull --all
+ls qa-tests/   # expect: pr-collision-test-<8hex>.yaml × 2
+
+# 3. Plant a legacy file; re-pull; expect "Legacy file:" warning.
+cp qa-tests/pr-collision-test-*.yaml qa-tests/pr-collision-test.yaml
+qa-use test sync pull --all 2>&1 | grep "Legacy file"
+
+# 4. Push by colliding name → exit 1 with disambiguation.
+qa-use test sync push --id "PR-collision-test" --dry-run; echo "exit=$?"
+# expect exit=1 and stdout listing both UUIDs
+
+# 5. Push by UUID → unambiguous.
+qa-use test sync push --id <uuid-1> --dry-run; echo "exit=$?"
+# expect exit=0, references one test
+
+# 6. Push by unique name → BC preserved.
+qa-use test sync push --id <some-other-unique-name> --dry-run; echo "exit=$?"
+# expect exit=0
+
+# 7. Cleanup
+qa-use api -X DELETE /api/v1/tests/<uuid-1>
+qa-use api -X DELETE /api/v1/tests/<uuid-2>
+rm -rf /tmp/qa-collision
+```
+
+If any step diverges from the expected output, do not merge — re-open the relevant phase.


### PR DESCRIPTION
## Summary

Test names are not unique within an org by design (`Test.matrix` is JSONB on a single row, so multiple rows legitimately share a `name`). The CLI assumed `name` is a usable handle in three places and silently picked the wrong row when two cloud tests shared a name. Reported in prod (org `org_33kGskJBHht2crEN6QXhYfXSU16`, "Verify EASM Assets Monitoring Dashboard Functionality" × 6 rows).

This PR closes all three vectors and bumps to **2.17.0**.

## What was done

| Phase | Commit | Files | What |
|---|---|---|---|
| 1 | `dadcf4d` | `src/cli/commands/test/sync.ts` (+45/-14) | New `findLocalForImported` helper; `renderImportResult` now prefers id-match and refuses to silently mis-target on name-only ambiguity. Folds in the staged working draft (`toUniqueTestFilename` for pull, push `--id` UUID-gating, `warnLegacyOrphan`, `export.ts` rewrite). |
| 2 | `41b87ba` | `src/cli/commands/test/sync.ts` + `sync.test.ts` (+201/-16) | Extracted `filterDefinitionsByHandle` as a pure exported function. 6 cases incl. uuid-shaped name (regression-guards `isUuid` gate). 5 cases for `findLocalForImported` incl. the trap (id mismatch + same-name id'd local must return null). |
| 3 | `d71e110` | `scripts/e2e.ts` (+290/-2) | Section 17 — 15 assertions: pull writes one suffixed file per row, legacy warning surfaces, push by colliding name exits 1, push by uuid exits 0. Backend-gated. |
| 4 | `3a930eb` | `package.json`, `README.md` (+3/-1) | 2.16.0 → **2.17.0**; one-paragraph migration callout under `## CLI Reference > ### Test Commands`. |
| plan | `8d3c619` | `thoughts/taras/plans/2026-05-07-name-collision-safe-test-sync.md` | Archive plan + deviations log alongside the diff. |

### Bonus work that landed on the same branch

| Commit | Files | What |
|---|---|---|
| `5e578a1` | `src/cli/commands/test/list.ts` (+4/-8) | **Show full UUIDs in `test list`.** Cloud `ID` was truncated to 10 chars and useless for copy-paste; widened to 36. Local list never had an `ID` column — added one (prints `-` when no id). Tunnel `id` is intentionally 10-hex sha256 and stays unchanged. |
| `6de78ca` | `scripts/e2e.ts` (+13/-9) | **Section 2 e2e workaround for DES-356.** Section 2 (Table Filtering) was failing on every run because `home → click("Table Demo")` triggers a React reconciliation crash under qa-use's tunneled session. The page itself is healthy (browser-use direct works on the same URL across Next 15.5.7/16.1.1/16.2.5 × React 19.1.0/19.2.3 — see DES-356 for the bisect). Section 2 now `browser create <url>/table` directly; same regression coverage, sidesteps the navigation trigger until DES-356 lands. |

DES-356: <https://linear.app/desplega-labs/issue/DES-356/qa-use-tunneled-browser-session-crashes-nextjs-client-side-link>

## Behavior change summary

* `pull` writes one file per cloud row as `${safe-name}-${short-id}.yaml` (first 8 hex chars of the UUID). No more silent overwrite when names collide.
* `push --id <name>` exits 1 when ≥2 local defs share that name; lists their paths + UUIDs and tells the user to disambiguate with `--id <uuid>`. Single-match by name still works (BC).
* Post-import map-back prefers id-match; falls back to name-match only when exactly one local def with that name has no id (first-push case). Otherwise warns and skips the version_hash writeback rather than picking the wrong file.
* Legacy un-suffixed files surface a one-line `Legacy file: ...` notice on next pull and are never auto-deleted.
* `qa-use test list` (and `--cloud`) print full UUIDs.

## Tests

* `bun test` — 579 pass / 0 fail across 76 files.
* `bun run typecheck` — clean.
* `bun run check:fix` — no fixes applied.
* `bun run scripts/e2e.ts` — Section 17 (new): 15/15 PASS against the configured backend. Section 2 (rewritten): smoke-tested under qa-use, filter-input snapshot intact.

## Plan status

`status: completed` (in `thoughts/taras/plans/2026-05-07-name-collision-safe-test-sync.md`). 18/21 checkboxes ticked. Three remain open and are tracked here:

- [ ] `bun run scripts/e2e.ts --cmd qa-use` against the installed binary — **blocked on publish**: PATH still has `qa-use 2.16.0`. Will satisfy after Taras publishes 2.17.0 post-merge.
- [ ] Run the full e2e against `localhost:5005` — substantively satisfied: ran 15/15 of Section 17 against `api.desplega.ai` (the actual backend the repo's `.qa-use.json` points at). The plan's literal `localhost:5005` text is a CLAUDE.md drift documented in the plan's Deviations section.
- [x] Note in the PR description that bumping argus templates is a follow-up downstream task — covered in "Follow-ups" below.

## Deviations from the plan (full table in the archived plan § Deviations)

* `pull` has no `--dir` / `--all` flags — Section 17 plants a per-tmp `.qa-use.json` and spawns the CLI with `cwd: <tmp>`.
* Public API has no `DELETE /api/v1/tests/{id}` (returns 405) — Section 17 cleanup is best-effort + per-run nonce so leaked rows are reapable. Backend follow-up wanted.
* CLAUDE.md drift: claims `.qa-use.json` is `localhost:5005`; actual file points at `https://api.desplega.ai`. Out of scope.
* Section 2 navigation crash turned out to be a qa-use bug (DES-356), not an evals app bug. Section 2 was rewritten to a direct-load form rather than fixed at the qa-use side in this PR.

## Follow-ups (not in this PR)

* Publish 2.17.0 → re-run `bun run scripts/e2e.ts --cmd qa-use` to satisfy the last unchecked plan box.
* Bump `cope/be/argus-template/build-template.py` to require qa-use ≥ 2.17.0 once published.
* DES-356: diagnose what qa-use's tunneled session injects/observes that breaks React's child reconciler on App Router `<Link>` navigation. Once fixed, revert Section 2 to the home → click form (one-line change).
* Add `DELETE /api/v1/tests/{id}` (or admin-namespaced equivalent) so e2e Section 17 doesn't leak rows.
* (Optional, cosmetic) Update `--id` metavar in help text from `<uuid>` to `<id-or-name>` to advertise the unique-name BC.
* (Optional) Update `CLAUDE.md` note: `.qa-use.json` points at `api.desplega.ai`, not `localhost:5005`.

## Test plan

- [ ] `bun install && bun run check:fix && bun run typecheck && bun test` — full suite green
- [ ] `bun run scripts/e2e.ts` — Section 17 + rewritten Section 2 pass against your configured backend
- [ ] Eyeball the README diff under `## CLI Reference > ### Test Commands` — the migration note reads cleanly
- [ ] `bun run cli test list` and `bun run cli test list --cloud` — confirm full UUIDs are printed (not `26abc1d2…`)
- [ ] Manual E2E (recipe at the bottom of the archived plan): pull → expect 2 suffixed files, plant a legacy file → expect "Legacy file:" warning, push by colliding name → exit 1, push by uuid → exit 0. Step 7's DELETE will WARN with 405 — reap rows manually