### PR TITLE
[chore] CLAUDE.md backend default + advertise --id name fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ Required: `QA_USE_API_KEY=xxx`. Optional: `QA_USE_REGION=us|auto` (default `auto
 
 A `~/.qa-use.json` config file is also supported. **Env vars take precedence over the file.** The file may include a top-level `"tunnel": "auto" | "on" | "off"` (see tunnel block below).
 
-For local backend work, the repo's `.qa-use.json` is pre-configured with `localhost:5005` and a valid API key — no extra env setup needed.
+The repo's `.qa-use.json` is pre-configured against `https://api.desplega.ai` with a valid `api_key` — no extra env setup needed. It also carries an underscore-prefixed `_api_url` / `_api_key` pair pointing at `http://localhost:5005`; swap the underscores to flip between prod and local backend without touching env vars.
 
 </important>
 
@@ -178,7 +178,7 @@ Requires `.qa-use.json` in the repo root (valid `api_key` + `api_url`) and the b
 
 <important if="you need to manually exercise browser CLI flows against a local backend (snapshot/click/screenshot/logs)">
 
-Test site is https://evals.desplega.ai/ (buttons, checkboxes, forms, tables for component testing). Repo `.qa-use.json` is pre-configured for `localhost:5005`.
+Test site is https://evals.desplega.ai/ (buttons, checkboxes, forms, tables for component testing). Repo `.qa-use.json` defaults to `https://api.desplega.ai`; swap the underscore prefix on `api_url` / `api_key` to flip to `http://localhost:5005` for local backend work.
 
 Representative flow:
 

--- a/src/cli/commands/test/sync.test.ts
+++ b/src/cli/commands/test/sync.test.ts
@@ -94,7 +94,9 @@ describe('syncCommand', () => {
     it('should have --id option', () => {
       const idOption = pushCommand?.options.find((o) => o.long === '--id');
       expect(idOption).toBeDefined();
-      expect(idOption?.description).toBe('Push single test by ID');
+      expect(idOption?.description).toBe(
+        'Push single test by UUID, or by name when unique among local files'
+      );
     });
 
     it('should have --all option', () => {
@@ -150,7 +152,7 @@ describe('syncCommand', () => {
 
       it('should parse --id option with argument', () => {
         const idOption = pushCommand?.options.find((o) => o.long === '--id');
-        expect(idOption?.flags).toContain('<uuid>');
+        expect(idOption?.flags).toContain('<id-or-name>');
       });
 
       it('should have boolean --all option (no argument)', () => {

--- a/src/cli/commands/test/sync.ts
+++ b/src/cli/commands/test/sync.ts
@@ -61,15 +61,15 @@ const pullCommand = new Command('pull')
 // Push subcommand
 const pushCommand = new Command('push')
   .description('Push local tests to cloud')
-  .option('--id <uuid>', 'Push single test by ID')
+  .option('--id <id-or-name>', 'Push single test by UUID, or by name when unique among local files')
   .option('--all', 'Push all local tests')
   .option('--dry-run', 'Show what would be synced without making changes')
   .option('--force', 'Overwrite cloud tests without version check')
   .action(async (options) => {
     // Require --id or --all
     if (!options.id && !options.all) {
-      console.log(error('Must specify --id <uuid> or --all'));
-      console.log('  Use --id to push a single test');
+      console.log(error('Must specify --id <id-or-name> or --all'));
+      console.log('  Use --id to push a single test (UUID, or name if unique locally)');
       console.log('  Use --all to push all local tests');
       process.exit(1);
     }


### PR DESCRIPTION
## Summary

Two follow-ups left over from #23 (the 2.17.0 PR):

* **CLAUDE.md drift.** Two call sites claimed `.qa-use.json` is pre-configured with `localhost:5005`. The active `api_url` actually points at `https://api.desplega.ai`; the localhost pair is underscore-prefixed (`_api_url` / `_api_key`) and you swap the prefix to flip backends. Updated both lines.
* **`--id` metavar.** `qa-use test sync push --id` accepts a unique name as a UUID alias (the BC kept in #23), but the help output advertised `<uuid>` only. Switched the metavar to `<id-or-name>` and updated the description to name the BC. Two existing unit-test assertions updated in lockstep so the suite stays green.

No behavior change — purely docs/help text.

## Test plan

- [ ] `bun run typecheck && bun run check:fix && bun test`
- [ ] `bun run cli test sync push --help` — confirm `--id <id-or-name>` shows up with the new description
- [ ] Read the CLAUDE.md diff — does the underscore-swap explanation make sense to a fresh reader?